### PR TITLE
[Refactor] #83 - JWT 인증 과정 주석 추가

### DIFF
--- a/src/main/java/dgu/sw/global/security/CustomUserDetails.java
+++ b/src/main/java/dgu/sw/global/security/CustomUserDetails.java
@@ -8,6 +8,11 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.Collections;
 
+/**
+ * Spring Security의 UserDetails 구현체
+ * - User 엔티티를 기반으로 인증 정보를 관리
+ * - 인증된 사용자의 ID, 이메일, 비밀번호를 포함
+ */
 @Getter
 public class CustomUserDetails implements UserDetails {
 
@@ -21,11 +26,19 @@ public class CustomUserDetails implements UserDetails {
         this.password = user.getPassword();
     }
 
+    /**
+     * 사용자의 권한을 반환하는 메서드 (현재는 빈 리스트 반환)
+     * - 역할(Role)이 필요하면 여기에 추가 가능
+     */
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.emptyList(); // 역할이 추가되면 여기서 관리 가능
     }
 
+    /**
+     * Spring Security에서 사용자명을 반환하는 메서드
+     * - 보통 email을 사용하지만, 여기서는 id를 사용
+     */
     @Override
     public String getUsername() {
         return String.valueOf(id);

--- a/src/main/java/dgu/sw/global/security/CustomUserDetailsService.java
+++ b/src/main/java/dgu/sw/global/security/CustomUserDetailsService.java
@@ -8,6 +8,10 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+/**
+ * Spring Security의 UserDetailsService 구현체
+ * - 데이터베이스에서 사용자 정보를 조회하여 반환
+ */
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {

--- a/src/main/java/dgu/sw/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/dgu/sw/global/security/JwtAuthenticationFilter.java
@@ -14,6 +14,12 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+/**
+ * JWT 인증 필터
+ * - 매 요청마다 실행되며, 요청의 Authorization 헤더에서 JWT를 추출하고 검증함.
+ * - JWT가 유효하면 AuthenticationManager를 사용하여 인증을 수행하고, SecurityContext에 저장함.
+ * - Spring Security의 OncePerRequestFilter를 상속하여, 요청당 한 번만 실행되도록 보장함.
+ */
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -27,9 +33,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             String token = jwtUtil.resolveToken(request);
             if (token != null && jwtUtil.validateToken(token)) {
+                // 인증 토큰 생성하고 AuthenticationManager를 통해 인증 수행
                 Authentication authentication = authenticationManager.authenticate(
                         new UsernamePasswordAuthenticationToken(token, null)
                 );
+                // 인증이 성공하면 SecurityContext에 저장하여 이후의 요청에서 인증 정보 활용 가능하게 함
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
         } catch (ExpiredJwtException e) {

--- a/src/main/java/dgu/sw/global/security/JwtAuthenticationProvider.java
+++ b/src/main/java/dgu/sw/global/security/JwtAuthenticationProvider.java
@@ -8,6 +8,11 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
 
+/**
+ * JWT 기반 인증을 수행하는 AuthenticationProvider 구현 클래스
+ * - JWT 토큰에서 사용자 정보를 추출하여 인증을 처리함
+ * - AuthenticationManager에 의해 호출되며, SecurityContext에 인증 객체를 저장함
+ */
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationProvider implements AuthenticationProvider {
@@ -29,6 +34,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         }
 
         CustomUserDetails userDetails = (CustomUserDetails) customUserDetailsService.loadUserByUserId(userId);
+        // 인증 객체 생성 및 반환 (SecurityContextHolder에 저장될 객체)
         return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
     }
 

--- a/src/main/java/dgu/sw/global/security/JwtTokenProvider.java
+++ b/src/main/java/dgu/sw/global/security/JwtTokenProvider.java
@@ -15,6 +15,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * JWT 토큰을 생성 및 관리하는 클래스
+ * - AccessToken 및 RefreshToken을 생성
+ * - RefreshToken을 Redis에 저장하여 관리
+ */
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {

--- a/src/main/java/dgu/sw/global/security/JwtUtil.java
+++ b/src/main/java/dgu/sw/global/security/JwtUtil.java
@@ -15,6 +15,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.logging.Logger;
 
+/**
+ * JWT 관련 유틸리티 클래스
+ * - JWT 검증 및 추출, 파싱 기능 제공
+ * - JWT를 HTTP 요청 및 응답에서 다룰 수 있도록 지원
+ */
 @Component
 @RequiredArgsConstructor
 public class JwtUtil {


### PR DESCRIPTION
## Related Issue 🍀
- #83 

<br>

## Key Changes 🔑
1️⃣ JWT 인증 필터 (JwtAuthenticationFilter)
- 요청에서 JWT 추출 → 유효성 검사 → AuthenticationManager에 인증 요청 → SecurityContext에 저장

2️⃣ JWT 인증 프로바이더 (JwtAuthenticationProvider)
- JWT에서 userId 추출 → DB에서 사용자 조회 → UsernamePasswordAuthenticationToken 생성

3️⃣ JWT 발급 (JwtTokenProvider)
- 로그인 성공 시 AccessToken, RefreshToken 생성 → RefreshToken은 Redis에 저장

4️⃣ Security 설정 (SecurityConfig)
- JWT 필터를 Security 필터 체인에 추가
- AuthenticationManager에 JwtAuthenticationProvider 등록

5️⃣ 사용자 정보 (CustomUserDetails)
- getUsername()이 id 또는 email을 반환할 수 있음 → authentication.getName() 값이 달라짐

<br>

## To Reviewers 🙏🏻
🚨 오류 발생
- [java.lang.NumberFormatException: For input string: "haeun@gmail.com"] 이런 오류가 뜸!
- getUsername()이 email을 반환해서, authentication.getName()에서 email이 반환됨. (원래 id가 반환되어야 함)
- Authentication 객체를 만들 때 getUsername()은 Principal 값으로 설정됨.
- 따라서 getUsername()이 email이 아니라 id를 반환하도록 바꿔줬음.
- 즉 authentication.getName()의 값은 CustomUserDetails.getUsername()에서 결정됨!