### PR TITLE
[Feature] #66 - 카카오 OAuth 로그인 기능 구현

### DIFF
--- a/src/main/java/dgu/sw/domain/auth/controller/AuthController.java
+++ b/src/main/java/dgu/sw/domain/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package dgu.sw.domain.auth.controller;
+
+import dgu.sw.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
+import dgu.sw.domain.auth.service.AuthService;
+import dgu.sw.global.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "Auth 컨트롤러", description = "소셜 로그인 관련 API")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/kakao/login/{code}")
+    @Operation(summary = "카카오 로그인 API", description = "카카오 로그인 API 입니다.")
+    public ApiResponse<AuthUserResponse> kakaoLogin(@PathVariable String code) {
+        return ApiResponse.onSuccess(authService.oAuthLogin(code));
+    }
+}

--- a/src/main/java/dgu/sw/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/dgu/sw/domain/auth/converter/AuthConverter.java
@@ -1,0 +1,29 @@
+package dgu.sw.domain.auth.converter;
+
+import dgu.sw.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
+import dgu.sw.domain.auth.dto.AuthUserProfile;
+import dgu.sw.domain.user.entity.User;
+import dgu.sw.global.security.OAuthProvider;
+
+public class AuthConverter {
+
+    public static User toUser(AuthUserProfile profile) {
+        return User.builder()
+                .email(profile.getEmail())
+                .nickname(profile.getNickname())
+                .profileImage(profile.getProfileImage())
+                .provider(OAuthProvider.KAKAO) // 카카오 로그인
+                .build();
+    }
+
+    public static AuthUserResponse toAuthUserResponse(User user, String accessToken, String refreshToken) {
+        return new AuthUserResponse(
+                user.getProvider().name(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getProfileImage(),
+                accessToken,
+                refreshToken
+        );
+    }
+}

--- a/src/main/java/dgu/sw/domain/auth/dto/AuthDTO.java
+++ b/src/main/java/dgu/sw/domain/auth/dto/AuthDTO.java
@@ -1,0 +1,82 @@
+package dgu.sw.domain.auth.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthDTO {
+    public static class AuthRequest {
+
+        @Getter
+        public static class AuthInfoRequest{
+            private String email;
+        }
+    }
+
+    public static class AuthResponse {
+
+        // 공통 OAuth 토큰 응답 (카카오, 구글, 네이버 공통 구조)
+        @Getter
+        public static class OAuthToken {
+            private String access_token;
+            private String token_type;
+            private String refresh_token;
+            private int expires_in;
+            private String scope;                      // 네이버/카카오는 있음
+            private int refresh_token_expires_in;     // 카카오 전용
+        }
+
+        // 카카오 프로필 응답 (카카오 전용)
+        @Getter
+        public static class KakaoProfile {
+            private Long id;
+            private String connected_at;
+            private Properties properties;
+            private KakaoAccount kakao_account;
+
+            @Getter
+            public static class Properties {
+                private String nickname;
+                private String profile_image;
+                private String thumbnail_image;
+            }
+
+            @Getter
+            public static class KakaoAccount {
+                private Boolean profile_nickname_needs_agreement;
+                private Boolean profile_image_needs_agreement;
+                private Profile profile;
+                private Boolean has_email;
+                private Boolean email_needs_agreement;
+                private Boolean is_email_valid;
+                private Boolean is_email_verified;
+                private String email;
+
+                @Getter
+                public static class Profile {
+                    private String nickname;
+                    private String thumbnail_image_url;
+                    private String profile_image_url;
+                    private Boolean is_default_image;
+                    private Boolean is_default_nickname;
+                }
+            }
+        }
+
+        // 프론트로 리턴하는 공통 유저 정보 응답 (Provider 구분 없이)
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        @Builder
+        public static class AuthUserResponse {
+            private String provider;        // KAKAO, GOOGLE, NAVER
+            private String email;
+            private String nickname;
+            private String profileImage;
+            private String accessToken;
+            private String refreshToken;
+        }
+    }
+}

--- a/src/main/java/dgu/sw/domain/auth/dto/AuthUserProfile.java
+++ b/src/main/java/dgu/sw/domain/auth/dto/AuthUserProfile.java
@@ -1,0 +1,30 @@
+package dgu.sw.domain.auth.dto;
+
+import dgu.sw.global.security.OAuthProvider;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 공통 OAuth 사용자 프로필 정보
+ */
+@Getter
+@Builder
+public class AuthUserProfile {
+
+    private OAuthProvider provider;    // KAKAO, GOOGLE, NAVER 구분
+    private String email;
+    private String nickname;
+    private String profileImage;
+
+    /**
+     * 카카오 프로필로부터 AuthUserProfile 생성
+     */
+    public static AuthUserProfile ofKakao(AuthDTO.AuthResponse.KakaoProfile profile) {
+        return AuthUserProfile.builder()
+                .provider(OAuthProvider.KAKAO)
+                .email(profile.getKakao_account().getEmail())
+                .nickname(profile.getProperties().getNickname())
+                .profileImage(profile.getProperties().getProfile_image())
+                .build();
+    }
+}

--- a/src/main/java/dgu/sw/domain/auth/repository/AuthRepository.java
+++ b/src/main/java/dgu/sw/domain/auth/repository/AuthRepository.java
@@ -1,0 +1,4 @@
+package dgu.sw.domain.auth.repository;
+
+public interface AuthRepository {
+}

--- a/src/main/java/dgu/sw/domain/auth/service/AuthService.java
+++ b/src/main/java/dgu/sw/domain/auth/service/AuthService.java
@@ -1,0 +1,7 @@
+package dgu.sw.domain.auth.service;
+
+import dgu.sw.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
+
+public interface AuthService {
+    AuthUserResponse oAuthLogin (String accessCode);
+}

--- a/src/main/java/dgu/sw/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,56 @@
+package dgu.sw.domain.auth.service;
+
+import dgu.sw.domain.auth.converter.AuthConverter;
+import dgu.sw.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
+import dgu.sw.domain.auth.dto.AuthUserProfile;
+import dgu.sw.domain.user.entity.User;
+import dgu.sw.domain.user.repository.UserRepository;
+import dgu.sw.global.security.JwtTokenProvider;
+import dgu.sw.global.security.OAuthProvider;
+import dgu.sw.global.security.OAuthUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final OAuthUtil oAuthUtil;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 카카오 로그인 처리
+     * - OAuth 인가 코드로 사용자 정보 조회
+     * - 기존 회원이면 로그인, 아니면 회원가입 후 JWT 발급
+     */
+    @Override
+    public AuthUserResponse oAuthLogin(String code) {
+        // 1. 카카오 액세스 토큰 요청
+        String accessToken = oAuthUtil.requestAccessToken(OAuthProvider.KAKAO, code);
+
+        // 2. 카카오 사용자 정보 요청
+        AuthUserProfile userProfile = oAuthUtil.requestUserProfile(OAuthProvider.KAKAO, accessToken);
+
+        // 3. DB에서 사용자 조회 또는 신규 회원가입
+        User user = userRepository.findByEmail(userProfile.getEmail())
+                .orElseGet(() -> registerNewUser(userProfile));
+
+        // 4. JWT AccessToken & RefreshToken 발급
+        String jwtAccessToken = jwtTokenProvider.generateAccessToken(user);
+        String jwtRefreshToken = jwtTokenProvider.generateRefreshToken(user);
+
+        // 5. 응답 DTO 변환 후 반환
+        return AuthConverter.toAuthUserResponse(user, jwtAccessToken, jwtRefreshToken);
+    }
+
+    /**
+     * 카카오 신규 회원가입
+     */
+    private User registerNewUser(AuthUserProfile profile) {
+        User newUser = AuthConverter.toUser(profile);
+        return userRepository.save(newUser);
+    }
+}

--- a/src/main/java/dgu/sw/domain/user/entity/User.java
+++ b/src/main/java/dgu/sw/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import dgu.sw.domain.manner.entity.FavoriteManner;
 import dgu.sw.domain.quiz.entity.QuizReviewList;
 import dgu.sw.domain.quiz.entity.UserQuiz;
 import dgu.sw.domain.voca.entity.FavoriteVoca;
+import dgu.sw.global.security.OAuthProvider;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -25,6 +26,9 @@ public class User {
     private String email;
     private String password;
     private LocalDate joinDate;
+    private String profileImage;
+    @Enumerated(EnumType.STRING)
+    private OAuthProvider provider;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserQuiz> userQuizzes;

--- a/src/main/java/dgu/sw/global/RootController.java
+++ b/src/main/java/dgu/sw/global/RootController.java
@@ -10,4 +10,10 @@ public class RootController {
     public ApiResponse<String> healthCheck() {
         return ApiResponse.onSuccess("I'm healthy!");
     }
+
+    @GetMapping("/")
+    public ApiResponse<String> defaultCheck() {
+        return ApiResponse.onSuccess("I'm healthy!");
+    }
+
 }

--- a/src/main/java/dgu/sw/global/config/SecurityConfig.java
+++ b/src/main/java/dgu/sw/global/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(
                                 new AntPathRequestMatcher("/"),
+                                new AntPathRequestMatcher("/api/auth/**"),
                                 new AntPathRequestMatcher("/api/user/**"),
                                 new AntPathRequestMatcher("/api/voca/**"),
                                 new AntPathRequestMatcher("/api/manners/**"),

--- a/src/main/java/dgu/sw/global/exception/OAuthException.java
+++ b/src/main/java/dgu/sw/global/exception/OAuthException.java
@@ -1,0 +1,9 @@
+package dgu.sw.global.exception;
+
+import dgu.sw.global.status.ErrorStatus;
+
+public class OAuthException extends GeneralException{
+    public OAuthException(ErrorStatus code) {
+        super(code);
+    }
+}

--- a/src/main/java/dgu/sw/global/security/OAuthConstants.java
+++ b/src/main/java/dgu/sw/global/security/OAuthConstants.java
@@ -1,0 +1,18 @@
+package dgu.sw.global.security;
+
+public class OAuthConstants {
+
+    // Token 요청 URL
+    public static final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    public static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+    public static final String NAVER_TOKEN_URL = "https://nid.naver.com/oauth2.0/token";
+
+    // Profile 요청 URL
+    public static final String KAKAO_PROFILE_URL = "https://kapi.kakao.com/v2/user/me";
+    public static final String GOOGLE_PROFILE_URL = "https://www.googleapis.com/oauth2/v3/userinfo";
+    public static final String NAVER_PROFILE_URL = "https://openapi.naver.com/v1/nid/me";
+
+    private OAuthConstants() {
+        // 상수 클래스는 인스턴스화 금지
+    }
+}

--- a/src/main/java/dgu/sw/global/security/OAuthProvider.java
+++ b/src/main/java/dgu/sw/global/security/OAuthProvider.java
@@ -1,0 +1,5 @@
+package dgu.sw.global.security;
+
+public enum OAuthProvider {
+    KAKAO, GOOGLE, NAVER, APPLE
+}

--- a/src/main/java/dgu/sw/global/security/OAuthUtil.java
+++ b/src/main/java/dgu/sw/global/security/OAuthUtil.java
@@ -1,0 +1,97 @@
+package dgu.sw.global.security;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dgu.sw.domain.auth.dto.AuthUserProfile;
+import dgu.sw.global.exception.OAuthException;
+import dgu.sw.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthUtil {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper;
+
+    @Value("${oauth.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${oauth.kakao.redirect-uri}")
+    private String kakaoRedirectUri;
+
+    public String requestAccessToken(OAuthProvider provider, String code) {
+
+        if (provider != OAuthProvider.KAKAO) {
+            throw new OAuthException(ErrorStatus.OAUTH_UNSUPPORTED_PROVIDER);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoClientId);
+        params.add("redirect_uri", kakaoRedirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(OAuthConstants.KAKAO_TOKEN_URL, request, String.class);
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new OAuthException(ErrorStatus.OAUTH_REQUEST_FAILED);
+        }
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(response.getBody());
+            return jsonNode.get("access_token").asText();
+        } catch (Exception e) {
+            throw new OAuthException(ErrorStatus.OAUTH_JSON_PARSE_ERROR);
+        }
+    }
+
+    public AuthUserProfile requestUserProfile(OAuthProvider provider, String accessToken) {
+        if (provider != OAuthProvider.KAKAO) {
+            throw new OAuthException(ErrorStatus.OAUTH_UNSUPPORTED_PROVIDER);
+        }
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(OAuthConstants.KAKAO_PROFILE_URL, HttpMethod.GET, request, String.class);
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            System.out.println("카카오 프로필 응답 오류: " + response.getBody());
+            throw new OAuthException(ErrorStatus.OAUTH_REQUEST_FAILED);
+        }
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(response.getBody());
+            JsonNode kakaoAccount = jsonNode.get("kakao_account");
+
+            if (kakaoAccount == null || !kakaoAccount.has("email") || !kakaoAccount.has("profile")) {
+                throw new OAuthException(ErrorStatus.OAUTH_JSON_PARSE_ERROR);
+            }
+
+            String email = kakaoAccount.get("email").asText();
+            String nickname = kakaoAccount.get("profile").get("nickname").asText();
+            String profileImage = kakaoAccount.get("profile").get("thumbnail_image_url").asText();
+
+            return AuthUserProfile.builder()
+                    .provider(OAuthProvider.KAKAO)
+                    .email(email)
+                    .nickname(nickname)
+                    .profileImage(profileImage)
+                    .build();
+        } catch (Exception e) {
+            throw new OAuthException(ErrorStatus.OAUTH_JSON_PARSE_ERROR);
+        }
+    }
+}

--- a/src/main/java/dgu/sw/global/status/ErrorStatus.java
+++ b/src/main/java/dgu/sw/global/status/ErrorStatus.java
@@ -48,8 +48,13 @@ public enum ErrorStatus implements BaseErrorCode {
     MANNER_LIST_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER4042", "해당 카테고리의 매너 리스트를 찾을 수 없습니다."),
     MANNER_SEARCH_NO_RESULTS(HttpStatus.NOT_FOUND, "MANNER4043", "검색 결과가 없습니다."),
     MANNER_ALREADY_FAVORITED(HttpStatus.BAD_REQUEST, "MANNER4001", "이미 즐겨찾기에 추가된 매너입니다."),
-    MANNER_FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER4044", "즐겨찾기에 없는 매너입니다.");
+    MANNER_FAVORITE_NOT_FOUND(HttpStatus.NOT_FOUND, "MANNER4044", "즐겨찾기에 없는 매너입니다."),
 
+    // OAuth 관련 에러
+    OAUTH_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "OAUTH4001", "OAuth 요청 처리 중 에러가 발생했습니다."),
+    OAUTH_UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "OAUTH4002", "지원하지 않는 소셜 로그인 방식입니다."),
+    OAUTH_JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, "OAUTH4003", "OAuth 응답 파싱에 실패했습니다."),
+    OAUTH_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "OAUTH4004", "OAuth 인증에 실패했습니다.");
 
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,5 +17,10 @@ spring:
     expiration: 3600000 # 1시간 (밀리초)
     refreshExpiration: 604800000 # 7일 (밀리초)
 
+oauth:
+  kakao:
+    client-id: ${KAKAO_CLIENT_ID}
+    redirect-uri: ${KAKAO_REDIRECT_URI}
+
 REDIS_HOST: ${REDIS_URL}
 REDIS_PORT: ${REDIS_PORT}


### PR DESCRIPTION
## Related Issue 🍀
- #66 

<br>

## Key Changes 🔑
✅ 카카오 OAuth 로그인 기능 추가
- OAuthUtil을 통해 OAuth 인가 코드로 액세스 토큰 요청
- 액세스 토큰을 이용해 카카오 사용자 정보 조회

✅ JWT 기반 로그인 처리
- 기존 회원이면 로그인 처리 및 JWT 발급
- 신규 회원이면 자동으로 회원가입 후 JWT 발급
- AuthServiceImpl에서 JWT AccessToken & RefreshToken 생성

✅ 데이터 변환 및 저장
- AuthConverter를 활용해 AuthUserResponse 변환
- UserRepository를 통해 DB 내 사용자 조회 및 저장

<br>

## To Reviewers 🙏🏻
✅ 카카오 OAuth 로그인 요청 정상 동작 확인
✅ JWT 토큰 정상 발급 및 응답 반환 확인
✅ 기존 회원 로그인 & 신규 회원 자동 가입 동작 확인