### PR TITLE
[Bug] #87 - RefreshToken 갱신 시 Redis 저장 토큰과 비교 후 새로운 Token 저장

### DIFF
--- a/src/main/java/dgu/sw/domain/user/controller/UserController.java
+++ b/src/main/java/dgu/sw/domain/user/controller/UserController.java
@@ -13,10 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -47,8 +44,8 @@ public class UserController {
 
     @PostMapping("/refresh")
     @Operation(summary = "토큰 갱신 API", description = "Refresh Token을 이용하여 Access Token을 갱신합니다.")
-    public ApiResponse<SignInResponse> refresh(@RequestBody String refreshToken) {
-        return ApiResponse.onSuccess(userService.refreshAccessToken(refreshToken));
+    public ApiResponse<SignInResponse> refresh(@RequestHeader("refreshToken") String refreshToken, HttpServletResponse response) {
+        return ApiResponse.onSuccess(userService.refreshAccessToken(refreshToken, response));
     }
 
     @PostMapping("/check-email")

--- a/src/main/java/dgu/sw/domain/user/service/UserService.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserService.java
@@ -14,7 +14,7 @@ public interface UserService {
 
     void signOut(HttpServletRequest request, HttpServletResponse response);
 
-    SignInResponse refreshAccessToken(String refreshToken);
+    SignInResponse refreshAccessToken(String refreshToken, HttpServletResponse response);
 
     void checkEmailDuplicate(String email);
 

--- a/src/main/java/dgu/sw/global/config/redis/RedisUtil.java
+++ b/src/main/java/dgu/sw/global/config/redis/RedisUtil.java
@@ -5,6 +5,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.security.SecureRandom;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 @Component
@@ -25,6 +26,11 @@ public class RedisUtil {
     // userId로 키 생성
     private String generateKey(String userId) {
         return userId;
+    }
+
+    // RefreshToken 가져오기 (Optional로 감싸서 Null 체크)
+    public Optional<String> getRefreshToken(String userId) {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(userId));
     }
 
     public void deleteRefreshToken(String userId) {


### PR DESCRIPTION
## Related Issue 🍀
- #87 

<br>

## Key Changes 🔑
- RefreshToken을 Request Body가 아닌 Request Header에서 받도록 변경
- Redis에서 userId를 기반으로 저장된 RefreshToken을 조회 후, 요청된 RefreshToken과 비교하여 일치할 경우에만 갱신
- 기존에는 기존 RefreshToken을 덮어쓰는 방식이었지만, 토큰을 완전히 삭제한 후 새 토큰을 저장하는 방식으로 변경

<br>

## To Reviewers 🙏🏻
- 