### PR TITLE
[Feature] #91 - 퀴즈 기능 확장을 위한 엔티티 수정 및 MockTest 도입

### DIFF
--- a/src/main/java/dgu/sw/domain/quiz/entity/MockTest.java
+++ b/src/main/java/dgu/sw/domain/quiz/entity/MockTest.java
@@ -1,0 +1,34 @@
+package dgu.sw.domain.quiz.entity;
+
+import dgu.sw.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "mockTest")
+public class MockTest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long mockTestId;
+
+    @ManyToOne
+    @JoinColumn(name = "userId")
+    private User user;
+
+    private LocalDate createdDate;
+
+    private boolean isCompleted; // 다 풀었는지 여부
+
+    private int correctCount;
+
+    @OneToMany(mappedBy = "mockTest", cascade = CascadeType.ALL)
+    private List<MockTestQuiz> mockTestQuizzes;
+}
+

--- a/src/main/java/dgu/sw/domain/quiz/entity/MockTestQuiz.java
+++ b/src/main/java/dgu/sw/domain/quiz/entity/MockTestQuiz.java
@@ -1,0 +1,27 @@
+package dgu.sw.domain.quiz.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "mockTestQuiz")
+public class MockTestQuiz {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long mockTestQuizId;
+
+    @ManyToOne
+    @JoinColumn(name = "mockTestId")
+    private MockTest mockTest;
+
+    @ManyToOne
+    @JoinColumn(name = "quizId")
+    private Quiz quiz;
+
+    private boolean isCorrect;
+}
+

--- a/src/main/java/dgu/sw/domain/quiz/entity/UserQuiz.java
+++ b/src/main/java/dgu/sw/domain/quiz/entity/UserQuiz.java
@@ -4,6 +4,8 @@ import dgu.sw.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDate;
+
 @Entity
 @Getter
 @Builder
@@ -18,6 +20,11 @@ public class UserQuiz {
     private boolean isLocked;
     private boolean isCorrect;
     private boolean isReviewed;
+
+    @Temporal(TemporalType.DATE)
+    private LocalDate solvedDate;
+
+    private Boolean retriedToday; // 오늘 다시 풀었는지 여부
 
     @ManyToOne
     @JoinColumn(name = "userId")


### PR DESCRIPTION
## Related Issue 🍀
- #91 

<br>

## Key Changes 🔑
- UserQuiz 엔티티에 solvedDate 필드 추가 (퀴즈 푼 날짜 저장)
- 어제 푼 퀴즈를 오늘 다시 풀었는지 (복습 여부) 확인하기 위해 UserQuiz에 retriedToday 필드 추가
- 모의고사 기능을 위한 MockTest, MockTestQuiz 엔티티 생성
- 어제 많이 틀린 퀴즈 Top5 조회 기능을 위한 데이터 구조 준비

<br>

## To Reviewers 🙏🏻
- 어제 푼 퀴즈를 오늘 다시 풀었는지 여부를 확인하기 위해, 같은 퀴즈를 오늘 날짜에 또 풀었는지 체크하면 되지만, UserQuiz에 퀴즈-날짜 기준의 복수 데이터가 들어가야 하므로, 지금 구조로 충분하지만 중복 방지를 위해 고유 제약 조건 추가함!