### PR TITLE
[Feature] #92 - 퀴즈 메인 페이지 조회 API 구현

### DIFF
--- a/src/main/java/dgu/sw/domain/quiz/controller/QuizController.java
+++ b/src/main/java/dgu/sw/domain/quiz/controller/QuizController.java
@@ -1,5 +1,6 @@
 package dgu.sw.domain.quiz.controller;
 
+import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizMainPageResponse;
 import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizSearchResponse;
 import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizReviewResponse;
 import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizListResponse;
@@ -83,6 +84,13 @@ public class QuizController {
             Authentication authentication,
             @RequestParam(required = false) String keyword) {
         List<QuizSearchResponse> response = quizService.searchQuizzes(authentication.getName(), keyword);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/main")
+    @Operation(summary = "퀴즈 메인 정보 조회", description = "어제 푼 퀴즈 수, 진척도, 모의고사 점수, Top5 오답 퀴즈 등 메인 페이지 데이터를 반환합니다.")
+    public ApiResponse<QuizMainPageResponse> getQuizMainInfo(Authentication authentication) {
+        QuizMainPageResponse response = quizService.getQuizMainPageData(authentication.getName());
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/converter/QuizConverter.java
+++ b/src/main/java/dgu/sw/domain/quiz/converter/QuizConverter.java
@@ -9,6 +9,7 @@ import dgu.sw.domain.quiz.entity.Quiz;
 import dgu.sw.domain.quiz.entity.UserQuiz;
 import dgu.sw.domain.user.entity.User;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public class QuizConverter {
@@ -20,6 +21,7 @@ public class QuizConverter {
                 .isCorrect(isCorrect)
                 .isLocked(false)
                 .isReviewed(false)
+                .solvedDate(LocalDate.now())
                 .build();
     }
 

--- a/src/main/java/dgu/sw/domain/quiz/dto/QuizDTO.java
+++ b/src/main/java/dgu/sw/domain/quiz/dto/QuizDTO.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class QuizDTO {
 
     public static class QuizRequest {
@@ -74,6 +76,16 @@ public class QuizDTO {
             private boolean isSolved;
             private boolean isInReviewList;
             private boolean isCorrect;
+        }
+
+        @Getter
+        @Builder
+        public static class QuizMainPageResponse {
+            private int yesterdaySolvedCount;
+            private double progressRate;
+            private Integer latestMockExamScore;
+            private Double topPercentile;
+            private List<QuizListResponse> top5WrongQuizzes;
         }
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/entity/UserQuiz.java
+++ b/src/main/java/dgu/sw/domain/quiz/entity/UserQuiz.java
@@ -37,4 +37,12 @@ public class UserQuiz {
     public void updateCorrect(boolean isCorrect) {
         this.isCorrect = isCorrect;
     }
+
+    public void updateSolvedDate(LocalDate solvedDate) {
+        this.solvedDate = solvedDate;
+    }
+
+    public void updateRetriedToday(boolean retriedToday) {
+        this.retriedToday = retriedToday;
+    }
 }

--- a/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
+++ b/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
@@ -1,0 +1,18 @@
+package dgu.sw.domain.quiz.repository;
+
+import dgu.sw.domain.quiz.entity.MockTest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MockTestRepository extends JpaRepository<MockTest, Long> {
+    MockTest findTopByUser_UserIdOrderByCreatedDateDesc(Long userId); // ✅
+    @Query("SELECT COUNT(me) FROM MockTest me WHERE me.isCompleted = true")
+    long countCompletedExams();
+
+    @Query("SELECT COUNT(me) FROM MockTest me WHERE me.correctCount > :score")
+    long countByCorrectCountGreaterThan(@Param("score") int score);
+
+}

--- a/src/main/java/dgu/sw/domain/quiz/repository/UserQuizRepository.java
+++ b/src/main/java/dgu/sw/domain/quiz/repository/UserQuizRepository.java
@@ -1,9 +1,13 @@
 package dgu.sw.domain.quiz.repository;
 
+import dgu.sw.domain.quiz.entity.Quiz;
 import dgu.sw.domain.quiz.entity.UserQuiz;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,4 +16,14 @@ public interface UserQuizRepository extends JpaRepository<UserQuiz, Long> {
     List<UserQuiz> findByUser_UserId(Long userId);
     boolean existsByUser_UserIdAndQuiz_QuizId(Long userId, Long quizId);
     Optional<UserQuiz> findByUser_UserIdAndQuiz_QuizId(Long userId, Long quizId);
+    @Query("SELECT COUNT(uq) FROM UserQuiz uq WHERE uq.user.userId = :userId AND uq.solvedDate = :date")
+    int countByUserIdAndSolvedDate(@Param("userId") Long userId, @Param("date") LocalDate date);
+
+    @Query("SELECT COUNT(DISTINCT uq.quiz.quizId) FROM UserQuiz uq WHERE uq.user.userId = :userId")
+    long countDistinctByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT uq.quiz FROM UserQuiz uq WHERE uq.solvedDate = :date AND uq.isCorrect = false GROUP BY uq.quiz ORDER BY COUNT(uq) DESC")
+    List<Quiz> findTop5MostWrongOnDate(@Param("date") LocalDate date);
+
+    boolean existsByUser_UserIdAndQuiz_QuizIdAndSolvedDate(Long userId, Long quizId, LocalDate solvedDate);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/QuizService.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/QuizService.java
@@ -1,5 +1,6 @@
 package dgu.sw.domain.quiz.service;
 
+import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizMainPageResponse;
 import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizReviewResponse;
 import dgu.sw.domain.quiz.dto.QuizDTO.QuizRequest.SubmitQuizRequest;
 import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizListResponse;
@@ -17,4 +18,5 @@ public interface QuizService {
     void removeQuizFromReview(String userId, Long quizId);
     List<QuizSearchResponse> searchQuizzes(String userId, String keyword);
     List<QuizReviewResponse> getReviewList(String userId);
+    QuizMainPageResponse getQuizMainPageData(String userId);
 }


### PR DESCRIPTION
## Related Issue 🍀
- #92 

<br>

## Key Changes 🔑
- 어제 푼 퀴즈 개수 반환
- 전체 퀴즈 대비 사용자 진척도 계산
- 최근 모의고사 점수 및 상위 퍼센트 조회
- 어제 가장 많이 틀린 퀴즈 Top 5 조회
- UserQuiz.solvedDate, retriedToday 기반 통계 처리

<br>

## To Reviewers 🙏🏻
- 