### PR TITLE
[Feature] #99 - 모의고사 관련 API 구현

### DIFF
--- a/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
+++ b/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
@@ -1,5 +1,6 @@
 package dgu.sw.domain.quiz.controller;
 
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
 import dgu.sw.domain.quiz.service.MockTestService;
 import dgu.sw.global.ApiResponse;
@@ -21,6 +22,15 @@ public class MockTestController {
     @Operation(summary = "모의고사 시작", description = "랜덤한 10개의 퀴즈로 모의고사를 시작합니다.")
     public ApiResponse<CreateMockTestResponse> startMockTest(Authentication authentication) {
         CreateMockTestResponse response = mockTestService.startMockTest(authentication.getName());
+        return ApiResponse.onSuccess(response);
+    }
+
+    @PostMapping("/{mockTestId}/submit")
+    @Operation(summary = "모의고사 제출", description = "사용자가 선택한 답안을 제출하고 결과를 반환합니다.")
+    public ApiResponse<CreateMockTestResponse> submitMockTest(
+            @PathVariable Long mockTestId,
+            @RequestBody SubmitMockTestRequest request) {
+        CreateMockTestResponse response = mockTestService.submitMockTest(mockTestId, request);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
+++ b/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
@@ -1,5 +1,6 @@
 package dgu.sw.domain.quiz.controller;
 
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
 import dgu.sw.domain.quiz.service.MockTestService;
@@ -27,10 +28,10 @@ public class MockTestController {
 
     @PostMapping("/{mockTestId}/submit")
     @Operation(summary = "모의고사 제출", description = "사용자가 선택한 답안을 제출하고 결과를 반환합니다.")
-    public ApiResponse<CreateMockTestResponse> submitMockTest(
+    public ApiResponse<SubmitMockTestResponse> submitMockTest(
             @PathVariable Long mockTestId,
             @RequestBody SubmitMockTestRequest request) {
-        CreateMockTestResponse response = mockTestService.submitMockTest(mockTestId, request);
+        SubmitMockTestResponse response = mockTestService.submitMockTest(mockTestId, request);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
+++ b/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
@@ -1,0 +1,26 @@
+package dgu.sw.domain.quiz.controller;
+
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
+import dgu.sw.domain.quiz.service.MockTestService;
+import dgu.sw.global.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/mockTest")
+@Tag(name = "mockTest 컨트롤러", description = "모의고사 관련 API")
+public class MockTestController {
+
+    private final MockTestService mockTestService;
+
+    @PostMapping("/start")
+    @Operation(summary = "모의고사 시작", description = "랜덤한 10개의 퀴즈로 모의고사를 시작합니다.")
+    public ApiResponse<CreateMockTestResponse> startMockTest(Authentication authentication) {
+        CreateMockTestResponse response = mockTestService.startMockTest(authentication.getName());
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
+++ b/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
@@ -1,11 +1,15 @@
 package dgu.sw.domain.quiz.converter;
 
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmittedQuizResult;
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.MockTestQuestionResponse;
 import dgu.sw.domain.quiz.entity.MockTest;
 import dgu.sw.domain.quiz.entity.MockTestQuiz;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class MockTestConverter {
@@ -20,6 +24,27 @@ public class MockTestConverter {
                 .isCompleted(mockTest.isCompleted())
                 .correctCount(mockTest.getCorrectCount())
                 .quizzes(quizResponses)
+                .build();
+    }
+
+    public static SubmitMockTestResponse toSubmitMockTestResponse(MockTest mockTest, List<MockTestQuiz> mockTestQuizzes, List<SubmitMockTestRequest.Answer> answers) {
+        // quizId → selectedAnswer 매핑
+        Map<Long, String> selectedAnswerMap = answers.stream()
+                .collect(Collectors.toMap(SubmitMockTestRequest.Answer::getQuizId, SubmitMockTestRequest.Answer::getSelectedAnswer));
+
+        List<SubmittedQuizResult> results = mockTestQuizzes.stream()
+                .map(mtq -> SubmittedQuizResult.builder()
+                        .quizId(mtq.getQuiz().getQuizId())
+                        .question(mtq.getQuiz().getQuestion())
+                        .selectedAnswer(selectedAnswerMap.get(mtq.getQuiz().getQuizId())) // 여기!
+                        .isCorrect(mtq.isCorrect())
+                        .build())
+                .collect(Collectors.toList());
+
+        return SubmitMockTestResponse.builder()
+                .mockTestId(mockTest.getMockTestId())
+                .correctCount(mockTest.getCorrectCount())
+                .results(results)
                 .build();
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
+++ b/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
@@ -1,0 +1,25 @@
+package dgu.sw.domain.quiz.converter;
+
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.MockTestQuestionResponse;
+import dgu.sw.domain.quiz.entity.MockTest;
+import dgu.sw.domain.quiz.entity.MockTestQuiz;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MockTestConverter {
+    public static CreateMockTestResponse toCreateMockTestResponse(MockTest mockTest, List<MockTestQuiz> mockTestQuizzes) {
+        List<MockTestQuestionResponse> quizResponses = mockTestQuizzes.stream()
+                .map(mtq -> new MockTestQuestionResponse(mtq.getQuiz().getQuizId(), mtq.getQuiz().getQuestion()))
+                .collect(Collectors.toList());
+
+        return CreateMockTestResponse.builder()
+                .mockTestId(mockTest.getMockTestId())
+                .createdDate(mockTest.getCreatedDate())
+                .isCompleted(mockTest.isCompleted())
+                .correctCount(mockTest.getCorrectCount())
+                .quizzes(quizResponses)
+                .build();
+    }
+}

--- a/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
+++ b/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
@@ -54,6 +54,21 @@ public class MockTestDTO {
             private String question;
         }
 
+        @Getter
+        @Builder
+        public static class SubmitMockTestResponse {
+            private Long mockTestId;
+            private int correctCount;
+            private List<SubmittedQuizResult> results;
+        }
 
+        @Getter
+        @Builder
+        public static class SubmittedQuizResult {
+            private Long quizId;
+            private String question;
+            private String selectedAnswer;
+            private boolean isCorrect;
+        }
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
+++ b/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
@@ -1,0 +1,57 @@
+package dgu.sw.domain.quiz.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class MockTestDTO {
+    public static class MockTestRequest {
+        @Getter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class SubmitMockTestRequest {
+            @NotNull
+            private Long mockTestId;
+
+            @NotNull
+            private List<Answer> answers;
+
+            @Getter
+            @AllArgsConstructor
+            @NoArgsConstructor
+            @Builder
+            public static class Answer {
+                @NotNull
+                private Long quizId;
+                @NotNull
+                private String selectedAnswer;
+            }
+        }
+    }
+
+    public static class MockTestResponse {
+
+        @Getter
+        @Builder
+        public static class CreateMockTestResponse {
+            private Long mockTestId;
+            private LocalDate createdDate;
+            private boolean isCompleted;
+            private int correctCount;
+            private List<MockTestQuestionResponse> quizzes;
+        }
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        public static class MockTestQuestionResponse {
+            private Long quizId;
+            private String question;
+        }
+    }
+}

--- a/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
+++ b/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
@@ -53,5 +53,7 @@ public class MockTestDTO {
             private Long quizId;
             private String question;
         }
+
+
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/entity/MockTest.java
+++ b/src/main/java/dgu/sw/domain/quiz/entity/MockTest.java
@@ -30,5 +30,10 @@ public class MockTest {
 
     @OneToMany(mappedBy = "mockTest", cascade = CascadeType.ALL)
     private List<MockTestQuiz> mockTestQuizzes;
+
+    public void updateCompleted(boolean isCorrect, int correctCount) {
+        this.isCompleted = isCorrect;
+        this.correctCount = correctCount;
+    }
 }
 

--- a/src/main/java/dgu/sw/domain/quiz/entity/MockTestQuiz.java
+++ b/src/main/java/dgu/sw/domain/quiz/entity/MockTestQuiz.java
@@ -23,5 +23,9 @@ public class MockTestQuiz {
     private Quiz quiz;
 
     private boolean isCorrect;
+
+    public void updateCorrect(boolean isCorrect) {
+        this.isCorrect = isCorrect;
+    }
 }
 

--- a/src/main/java/dgu/sw/domain/quiz/repository/MockTestQuizRepository.java
+++ b/src/main/java/dgu/sw/domain/quiz/repository/MockTestQuizRepository.java
@@ -1,0 +1,14 @@
+package dgu.sw.domain.quiz.repository;
+
+import dgu.sw.domain.quiz.entity.MockTestQuiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MockTestQuizRepository extends JpaRepository<MockTestQuiz, Long> {
+
+    List<MockTestQuiz> findByMockTest_MockTestId(Long mockTestId);
+}
+

--- a/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
+++ b/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
@@ -6,13 +6,16 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface MockTestRepository extends JpaRepository<MockTest, Long> {
-    MockTest findTopByUser_UserIdOrderByCreatedDateDesc(Long userId); // ✅
+    MockTest findTopByUser_UserIdOrderByCreatedDateDesc(Long userId);
     @Query("SELECT COUNT(me) FROM MockTest me WHERE me.isCompleted = true")
     long countCompletedExams();
 
     @Query("SELECT COUNT(me) FROM MockTest me WHERE me.correctCount > :score")
     long countByCorrectCountGreaterThan(@Param("score") int score);
 
+    List<MockTest> findByUser_UserId(Long userId);
 }

--- a/src/main/java/dgu/sw/domain/quiz/repository/QuizRepository.java
+++ b/src/main/java/dgu/sw/domain/quiz/repository/QuizRepository.java
@@ -20,4 +20,7 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
     // 현재 풀려는 퀴즈보다 작은 ID 중에서 가장 큰 ID(즉, 바로 이전 퀴즈) 찾기
     @Query("SELECT MAX(q.quizId) FROM Quiz q WHERE q.category = :category AND q.quizId < :quizId")
     Long findPreviousQuizId(@Param("category") String category, @Param("quizId") Long quizId);
+
+    @Query(value = "SELECT * FROM quiz ORDER BY RAND() LIMIT :limit", nativeQuery = true)
+    List<Quiz> findRandomQuizzes(@Param("limit") int limit);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
@@ -1,9 +1,10 @@
 package dgu.sw.domain.quiz.service;
 
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
 
 public interface MockTestService {
     CreateMockTestResponse startMockTest(String userId);
-    CreateMockTestResponse submitMockTest(Long mockTestId, SubmitMockTestRequest request);
+    SubmitMockTestResponse submitMockTest(Long mockTestId, SubmitMockTestRequest request);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
@@ -1,0 +1,7 @@
+package dgu.sw.domain.quiz.service;
+
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
+
+public interface MockTestService {
+    CreateMockTestResponse startMockTest(String userId);
+}

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
@@ -1,7 +1,9 @@
 package dgu.sw.domain.quiz.service;
 
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
 
 public interface MockTestService {
     CreateMockTestResponse startMockTest(String userId);
+    CreateMockTestResponse submitMockTest(Long mockTestId, SubmitMockTestRequest request);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
@@ -1,6 +1,7 @@
 package dgu.sw.domain.quiz.service;
 
 import dgu.sw.domain.quiz.converter.MockTestConverter;
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
 import dgu.sw.domain.quiz.entity.MockTest;
@@ -62,13 +63,12 @@ public class MockTestServiceImpl implements MockTestService {
 
     @Override
     @Transactional
-    public CreateMockTestResponse submitMockTest(Long mockTestId, SubmitMockTestRequest request) {
+    public SubmitMockTestResponse submitMockTest(Long mockTestId, SubmitMockTestRequest request) {
         MockTest mockTest = mockTestRepository.findById(mockTestId)
                 .orElseThrow(() -> new QuizException(ErrorStatus.QUIZ_NOT_FOUND));
 
         List<MockTestQuiz> mockTestQuizzes = mockTestQuizRepository.findByMockTest_MockTestId(mockTestId);
 
-        // 정답 개수 업데이트
         int correctCount = 0;
         for (SubmitMockTestRequest.Answer answer : request.getAnswers()) {
             MockTestQuiz quizRecord = mockTestQuizzes.stream()
@@ -78,14 +78,12 @@ public class MockTestServiceImpl implements MockTestService {
 
             boolean isCorrect = quizRecord.getQuiz().getAnswer().equals(answer.getSelectedAnswer());
             quizRecord.updateCorrect(isCorrect);
-
             if (isCorrect) correctCount++;
         }
 
-        // 모의고사 완료 상태 업데이트
         mockTest.updateCompleted(true, correctCount);
         mockTestRepository.save(mockTest);
 
-        return MockTestConverter.toCreateMockTestResponse(mockTest, mockTestQuizzes);
+        return MockTestConverter.toSubmitMockTestResponse(mockTest, mockTestQuizzes, request.getAnswers());
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
@@ -1,0 +1,59 @@
+package dgu.sw.domain.quiz.service;
+
+import dgu.sw.domain.quiz.converter.MockTestConverter;
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
+import dgu.sw.domain.quiz.entity.MockTest;
+import dgu.sw.domain.quiz.entity.MockTestQuiz;
+import dgu.sw.domain.quiz.entity.Quiz;
+import dgu.sw.domain.quiz.repository.MockTestQuizRepository;
+import dgu.sw.domain.quiz.repository.MockTestRepository;
+import dgu.sw.domain.quiz.repository.QuizRepository;
+import dgu.sw.domain.user.entity.User;
+import dgu.sw.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MockTestServiceImpl implements MockTestService {
+    private final MockTestRepository mockTestRepository;
+    private final QuizRepository quizRepository;
+    private final UserRepository userRepository;
+    private final MockTestQuizRepository mockTestQuizRepository;
+
+    @Override
+    @Transactional
+    public CreateMockTestResponse startMockTest(String userId) {
+        User user = userRepository.findByUserId(Long.valueOf(userId));
+
+        // 랜덤한 10문제 가져오기
+        List<Quiz> randomQuizzes = quizRepository.findRandomQuizzes(10);
+
+        // 모의고사 생성
+        MockTest mockTest = MockTest.builder()
+                .user(user)
+                .createdDate(LocalDate.now())
+                .isCompleted(false)
+                .correctCount(0)
+                .build();
+        mockTestRepository.save(mockTest);
+
+        // 모의고사 문제 저장
+        List<MockTestQuiz> mockTestQuizzes = randomQuizzes.stream()
+                .map(quiz -> MockTestQuiz.builder()
+                        .mockTest(mockTest)
+                        .quiz(quiz)
+                        .isCorrect(false) // 초기값 설정
+                        .build())
+                .collect(Collectors.toList());
+
+        mockTestQuizRepository.saveAll(mockTestQuizzes);
+
+        return MockTestConverter.toCreateMockTestResponse(mockTest, mockTestQuizzes);
+    }
+}


### PR DESCRIPTION
## Related Issue 🍀
- #99 

<br>

## Key Changes 🔑
- 랜덤한 10개의 퀴즈를 선택하여 모의고사를 생성
- 생성된 모의고사 정보를 반환 (mockTestId, 문제 목록 포함)
- 사용자가 선택한 답안을 저장하고 정답 개수 카운트
- 제출된 모의고사의 completed 상태 업데이트
- 응답에서 사용자가 제출한 selectedAnswer까지 반환하여 결과 확인 가능

<br>

## To Reviewers 🙏🏻
- 