### PR TITLE
[Feature] #101 - 모의고사 결과 조회 API 구현 및 불필요한 계산 제거

### DIFF
--- a/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
+++ b/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
@@ -1,5 +1,6 @@
 package dgu.sw.domain.quiz.controller;
 
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.MockTestResultResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
@@ -32,6 +33,13 @@ public class MockTestController {
             @PathVariable Long mockTestId,
             @RequestBody SubmitMockTestRequest request) {
         SubmitMockTestResponse response = mockTestService.submitMockTest(mockTestId, request);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/{mockTestId}/result")
+    @Operation(summary = "모의고사 결과 조회", description = "모의고사 결과를 반환합니다.")
+    public ApiResponse<MockTestResultResponse> getMockTestResult(@PathVariable Long mockTestId) {
+        MockTestResultResponse response = mockTestService.getMockTestResult(mockTestId);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
+++ b/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
@@ -44,6 +44,7 @@ public class MockTestConverter {
         return SubmitMockTestResponse.builder()
                 .mockTestId(mockTest.getMockTestId())
                 .correctCount(mockTest.getCorrectCount())
+                .topPercentile(mockTest.getTopPercentile())
                 .results(results)
                 .build();
     }

--- a/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
+++ b/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
@@ -70,5 +70,36 @@ public class MockTestDTO {
             private String selectedAnswer;
             private boolean isCorrect;
         }
+
+        @Getter
+        @Builder
+        public static class MockTestResultResponse {
+            private Long mockTestId;
+            private int attemptCount; // 몇 번째 모의고사인지
+            private int score; // 100점 만점 기준
+            private int scoreChange; // 이전 모의고사 대비 상승/하락 점수
+            private double topPercentile; // 상위 % 위치
+            private double topPercentileChange; // 이전 모의고사 대비 등락률
+
+            private List<CategoryResult> categoryResults; // 카테고리별 정답 수
+            private List<MockTestQuestionResult> questionResults; // 전체 문제 목록
+
+            @Getter
+            @Builder
+            public static class CategoryResult {
+                private String category;
+                private int correctCount;
+                private int totalCount;
+            }
+
+            @Getter
+            @Builder
+            public static class MockTestQuestionResult {
+                private Long quizId;
+                private String category;
+                private String question;
+                private boolean isCorrect;
+            }
+        }
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
+++ b/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
@@ -59,6 +59,7 @@ public class MockTestDTO {
         public static class SubmitMockTestResponse {
             private Long mockTestId;
             private int correctCount;
+            private double topPercentile;
             private List<SubmittedQuizResult> results;
         }
 

--- a/src/main/java/dgu/sw/domain/quiz/entity/MockTest.java
+++ b/src/main/java/dgu/sw/domain/quiz/entity/MockTest.java
@@ -28,12 +28,15 @@ public class MockTest {
 
     private int correctCount;
 
+    private double topPercentile;
+
     @OneToMany(mappedBy = "mockTest", cascade = CascadeType.ALL)
     private List<MockTestQuiz> mockTestQuizzes;
 
-    public void updateCompleted(boolean isCorrect, int correctCount) {
+    public void updateCompleted(boolean isCorrect, int correctCount, double topPercentile) {
         this.isCompleted = isCorrect;
         this.correctCount = correctCount;
+        this.topPercentile = topPercentile;
     }
 }
 

--- a/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
+++ b/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
@@ -1,12 +1,14 @@
 package dgu.sw.domain.quiz.repository;
 
 import dgu.sw.domain.quiz.entity.MockTest;
+import dgu.sw.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface MockTestRepository extends JpaRepository<MockTest, Long> {
@@ -17,5 +19,9 @@ public interface MockTestRepository extends JpaRepository<MockTest, Long> {
     @Query("SELECT COUNT(me) FROM MockTest me WHERE me.correctCount > :score")
     long countByCorrectCountGreaterThan(@Param("score") int score);
 
-    List<MockTest> findByUser_UserId(Long userId);
+    List<MockTest> findByUser_UserIdOrderByCreatedDateAsc(Long userId);
+
+    List<MockTest> findAllByIsCompletedTrue();
+
+    Optional<MockTest> findTopByUser_UserIdAndMockTestIdLessThanOrderByMockTestIdDesc(Long userId, Long mockTestId);
 }

--- a/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
+++ b/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
@@ -24,4 +24,6 @@ public interface MockTestRepository extends JpaRepository<MockTest, Long> {
     List<MockTest> findAllByIsCompletedTrue();
 
     Optional<MockTest> findTopByUser_UserIdAndMockTestIdLessThanOrderByMockTestIdDesc(Long userId, Long mockTestId);
+
+    List<MockTest> findByUser_UserIdAndMockTestIdLessThan(Long userId, Long mockTestId);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
@@ -1,5 +1,6 @@
 package dgu.sw.domain.quiz.service;
 
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.MockTestResultResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
@@ -7,4 +8,5 @@ import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestRespons
 public interface MockTestService {
     CreateMockTestResponse startMockTest(String userId);
     SubmitMockTestResponse submitMockTest(Long mockTestId, SubmitMockTestRequest request);
+    MockTestResultResponse getMockTestResult(Long mockTestId);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
@@ -1,6 +1,8 @@
 package dgu.sw.domain.quiz.service;
 
 import dgu.sw.domain.quiz.converter.MockTestConverter;
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.MockTestResultResponse;
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.MockTestResultResponse.MockTestQuestionResult;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
@@ -19,7 +21,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -85,5 +90,115 @@ public class MockTestServiceImpl implements MockTestService {
         mockTestRepository.save(mockTest);
 
         return MockTestConverter.toSubmitMockTestResponse(mockTest, mockTestQuizzes, request.getAnswers());
+    }
+
+    @Override
+    public MockTestResultResponse getMockTestResult(Long mockTestId) {
+        // 1. 모의고사 정보 가져오기
+        MockTest mockTest = mockTestRepository.findById(mockTestId)
+                .orElseThrow(() -> new QuizException(ErrorStatus.MOCK_TEST_NOT_COMPLETED));
+
+        List<MockTestQuiz> mockTestQuizzes = mockTestQuizRepository.findByMockTest_MockTestId(mockTestId);
+
+        // 2. 전체 문제 정보 가공
+        List<MockTestQuestionResult> questionResults = mockTestQuizzes.stream()
+                .map(mtq -> MockTestResultResponse.MockTestQuestionResult.builder()
+                        .quizId(mtq.getQuiz().getQuizId())
+                        .category(mtq.getQuiz().getCategory())
+                        .question(mtq.getQuiz().getQuestion())
+                        .isCorrect(mtq.isCorrect())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 3. 카테고리별 정답 개수 계산
+        Map<String, Long> totalQuestionsByCategory = mockTestQuizzes.stream()
+                .collect(Collectors.groupingBy(mtq -> mtq.getQuiz().getCategory(), Collectors.counting()));
+
+        Map<String, Long> correctQuestionsByCategory = mockTestQuizzes.stream()
+                .filter(MockTestQuiz::isCorrect)
+                .collect(Collectors.groupingBy(mtq -> mtq.getQuiz().getCategory(), Collectors.counting()));
+
+        List<MockTestResultResponse.CategoryResult> categoryResults = totalQuestionsByCategory.entrySet().stream()
+                .map(entry -> MockTestResultResponse.CategoryResult.builder()
+                        .category(entry.getKey())
+                        .correctCount(correctQuestionsByCategory.getOrDefault(entry.getKey(), 0L).intValue())
+                        .totalCount(entry.getValue().intValue())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 4. 해당 모의고사가 몇 번째인지 계산
+        List<MockTest> userMockTests = mockTestRepository.findByUser_UserIdOrderByCreatedDateAsc(mockTest.getUser().getUserId());
+        int attemptCount = userMockTests.indexOf(mockTest) + 1; // 1부터 시작하는 순서
+
+        // 현재 모의고사까지 포함한 내 평균 점수 계산
+        double myAverageScore = userMockTests.stream()
+                .filter(mt -> mt.getMockTestId() <= mockTestId) // 이 모의고사 이전 데이터만 사용
+                .mapToDouble(mt -> ((double) mt.getCorrectCount() / mt.getMockTestQuizzes().size()) * 100)
+                .average()
+                .orElse(0.0);
+
+        // 다른 사용자들의 평균 점수를 `mockTestId` 이전 모의고사 기준으로 계산
+        List<MockTest> completedTests = mockTestRepository.findAllByIsCompletedTrue();
+        List<Double> allUserAverageScores = completedTests.stream()
+                .filter(mt -> mt.getMockTestId() <= mockTestId) // 이 모의고사 이전 데이터만 사용
+                .collect(Collectors.groupingBy(MockTest::getUser, Collectors.averagingDouble(
+                        mt -> ((double) mt.getCorrectCount() / mt.getMockTestQuizzes().size()) * 100)))
+                .values()
+                .stream()
+                .collect(Collectors.toList());
+
+        // 내 평균 점수를 포함
+        allUserAverageScores.add(myAverageScore);
+
+        // 내림차순 정렬 (점수가 높은 사람이 1등)
+        allUserAverageScores.sort(Comparator.reverseOrder());
+
+        long totalParticipants = allUserAverageScores.size();
+
+        // 내 평균 점수 기준으로 등수 계산 (내 점수가 포함된 상태에서)
+        int myRank = allUserAverageScores.indexOf(myAverageScore) + 1; // 등수는 1부터 시작
+
+        // 현재 점수 계산
+        int score = (int) ((double) mockTest.getCorrectCount() / mockTestQuizzes.size() * 100);
+
+        // 현재 모의고사 정보
+        Long currentMockTestId = mockTest.getMockTestId();
+        Long userId = mockTest.getUser().getUserId();
+
+        // 현재 모의고사를 푼 유저가 푼 mockTestId 중 현재 mockTestId보다 작은 것들 중 가장 큰 것
+        Optional<MockTest> previousMockTestOpt = mockTestRepository.findTopByUser_UserIdAndMockTestIdLessThanOrderByMockTestIdDesc(userId, currentMockTestId);
+
+        // 이전 점수 및 변화량 계산
+        int scoreChange = 0;
+
+        // 상위 퍼센트 계산 (점수가 높을수록 0에 가까워짐)
+        double topPercentile = totalParticipants > 0 ? ((double) myRank / totalParticipants * 100) : 0.0;
+        double previousTopPercentile = topPercentile;
+
+        if (previousMockTestOpt.isPresent()) {
+            MockTest previousMockTest = previousMockTestOpt.get();
+            List<MockTestQuiz> previousQuizzes = mockTestQuizRepository.findByMockTest_MockTestId(previousMockTest.getMockTestId());
+            int previousScore = previousQuizzes.size() > 0
+                    ? (int) ((double) previousMockTest.getCorrectCount() / previousQuizzes.size() * 100)
+                    : 0;
+            scoreChange = score - previousScore;
+
+            // 이전 상위 퍼센트 계산 (이전 평균 점수를 기준으로 다시 계산해도 됨. 여기선 현재와 동일하게 처리)
+            previousTopPercentile = ((double) (allUserAverageScores.indexOf(myAverageScore) + 1) / totalParticipants * 100);
+        }
+
+        double topPercentileChange = previousTopPercentile - topPercentile;
+
+        // 7. 최종 결과 반환
+        return MockTestResultResponse.builder()
+                .mockTestId(mockTestId)
+                .score(score)
+                .attemptCount(attemptCount)
+                .scoreChange(scoreChange)
+                .topPercentile(topPercentile)
+                .topPercentileChange(topPercentileChange)
+                .categoryResults(categoryResults)
+                .questionResults(questionResults)
+                .build();
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/QuizServiceImpl.java
@@ -291,10 +291,7 @@ public class QuizServiceImpl implements QuizService {
         Integer recentScore = recentExam != null ? recentExam.getCorrectCount() * 10 : null;
 
         // 상위 % 계산
-        long totalParticipants = mockTestRepository.countCompletedExams();
-        long betterThan = recentScore != null ? mockTestRepository.countByCorrectCountGreaterThan(recentScore) : 0;
-        double topPercentile = totalParticipants > 0 ? (double) betterThan / totalParticipants : 1.0;
-
+        Double topPercentile = recentExam != null ? recentExam.getTopPercentile() : null;
         // 어제 많이 틀린 Top5 퀴즈
         List<Quiz> top5Wrong = userQuizRepository.findTop5MostWrongOnDate(LocalDate.now().minusDays(1));
         List<QuizListResponse> top5Responses = top5Wrong.stream()

--- a/src/main/java/dgu/sw/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/QuizServiceImpl.java
@@ -288,7 +288,7 @@ public class QuizServiceImpl implements QuizService {
 
         // 최근 모의고사 점수
         MockTest recentExam = mockTestRepository.findTopByUser_UserIdOrderByCreatedDateDesc(uid);
-        Integer recentScore = recentExam != null ? recentExam.getCorrectCount() : null;
+        Integer recentScore = recentExam != null ? recentExam.getCorrectCount() * 10 : null;
 
         // 상위 % 계산
         long totalParticipants = mockTestRepository.countCompletedExams();

--- a/src/main/java/dgu/sw/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/QuizServiceImpl.java
@@ -284,7 +284,7 @@ public class QuizServiceImpl implements QuizService {
         long totalQuizCount = quizRepository.count();
         long userSolvedCount = userQuizRepository.countDistinctByUserId(uid);
 
-        double progressRate = (double) userSolvedCount / totalQuizCount;
+        double progressRate = (double) userSolvedCount / totalQuizCount * 100;
 
         // 최근 모의고사 점수
         MockTest recentExam = mockTestRepository.findTopByUser_UserIdOrderByCreatedDateDesc(uid);

--- a/src/main/java/dgu/sw/global/status/ErrorStatus.java
+++ b/src/main/java/dgu/sw/global/status/ErrorStatus.java
@@ -54,9 +54,10 @@ public enum ErrorStatus implements BaseErrorCode {
     OAUTH_REQUEST_FAILED(HttpStatus.BAD_REQUEST, "OAUTH4001", "OAuth 요청 처리 중 에러가 발생했습니다."),
     OAUTH_UNSUPPORTED_PROVIDER(HttpStatus.BAD_REQUEST, "OAUTH4002", "지원하지 않는 소셜 로그인 방식입니다."),
     OAUTH_JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, "OAUTH4003", "OAuth 응답 파싱에 실패했습니다."),
-    OAUTH_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "OAUTH4004", "OAuth 인증에 실패했습니다.");
+    OAUTH_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "OAUTH4004", "OAuth 인증에 실패했습니다."),
 
-
+    // 모의고사 관련 에러
+    MOCK_TEST_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MOCK4001", "아직 제출되지 않은 모의고사입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## Related Issue 🍀
- #101 

<br>

## Key Changes 🔑
- 모의고사 제출 시 본인의 평균 점수를 기준으로 전체 사용자 평균과 비교해 상위 퍼센트 계산 및 저장
- 모의고사 결과 조회 시 상위 퍼센트 및 변화량 계산 간소화 (DB 값 사용)
- 'MockTest' 엔티티에 'topPercentile' 컬럼 추가 및 매핑
- 퀴즈 메인 페이지 조회 시 최근 모의고사 점수 계산 단위를 '%'로 변경
- 상위 퍼센트 계산 오류 수정 및 일관성 유지
- 불필요한 등수 계산 로직 제거로 성능 및 가독성 개선

<br>

## To Reviewers 🙏🏻
- 상위 퍼센트 계산하느라 애 먹었다능