### PR TITLE
[Feature] #103 - 이전 모의고사 결과 조회 API 구현

### DIFF
--- a/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
+++ b/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
@@ -42,4 +42,11 @@ public class MockTestController {
         MockTestResultResponse response = mockTestService.getMockTestResult(mockTestId);
         return ApiResponse.onSuccess(response);
     }
+
+    @GetMapping("/previous/result")
+    @Operation(summary = "이전 모의고사 결과 조회", description = "가장 최근에 완료한 이전 모의고사 결과를 조회합니다.")
+    public ApiResponse<MockTestResultResponse> getPreviousMockTestResult(Authentication authentication) {
+        MockTestResultResponse response = mockTestService.getPreviousMockTestResult(authentication.getName());
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
+++ b/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
@@ -26,4 +26,6 @@ public interface MockTestRepository extends JpaRepository<MockTest, Long> {
     Optional<MockTest> findTopByUser_UserIdAndMockTestIdLessThanOrderByMockTestIdDesc(Long userId, Long mockTestId);
 
     List<MockTest> findByUser_UserIdAndMockTestIdLessThan(Long userId, Long mockTestId);
+
+    Optional<MockTest> findTopByUser_UserIdAndIsCompletedTrueOrderByCreatedDateDesc(Long userId);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
@@ -9,4 +9,5 @@ public interface MockTestService {
     CreateMockTestResponse startMockTest(String userId);
     SubmitMockTestResponse submitMockTest(Long mockTestId, SubmitMockTestRequest request);
     MockTestResultResponse getMockTestResult(Long mockTestId);
+    MockTestResultResponse getPreviousMockTestResult(String userId);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
@@ -197,4 +197,19 @@ public class MockTestServiceImpl implements MockTestService {
                 .questionResults(questionResults)
                 .build();
     }
+
+    @Override
+    public MockTestResultResponse getPreviousMockTestResult(String userId) {
+        Long uid = Long.valueOf(userId);
+
+        // 유저가 푼 가장 최근(제일 마지막) 이전 모의고사
+        Optional<MockTest> previousMockTestOpt = mockTestRepository
+                .findTopByUser_UserIdAndIsCompletedTrueOrderByCreatedDateDesc(uid);
+
+        MockTest mockTest = previousMockTestOpt
+                .orElseThrow(() -> new QuizException(ErrorStatus.MOCK_TEST_NOT_FOUND));
+
+        return getMockTestResult(mockTest.getMockTestId());
+    }
+
 }

--- a/src/main/java/dgu/sw/global/status/ErrorStatus.java
+++ b/src/main/java/dgu/sw/global/status/ErrorStatus.java
@@ -57,7 +57,8 @@ public enum ErrorStatus implements BaseErrorCode {
     OAUTH_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "OAUTH4004", "OAuth 인증에 실패했습니다."),
 
     // 모의고사 관련 에러
-    MOCK_TEST_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MOCK4001", "아직 제출되지 않은 모의고사입니다.");
+    MOCK_TEST_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MOCK4001", "아직 제출되지 않은 모의고사입니다."),
+    MOCK_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "MOCK4002", "해당 모의고사를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## Related Issue 🍀
- #103 

<br>

## Key Changes 🔑
- 현재 mockTestId 기준으로 해당 사용자가 푼 가장 최근 이전 모의고사 결과 반환
- 이전 모의고사가 존재하지 않는 경우, 'MOCK_TEST_NOT_FOUND' 예외 반환
- 불필요한 로직 없이 기존 'getMockTestResult' 로직 재활용

<br>

## To Reviewers 🙏🏻
- '이전'보다 '최근' 모의고사 조회라고 표현하는 게 더 좋을 듯!