### PR TITLE
[Refactor] #107 - 카카오 SDK 기반 로그인 구현 및 신규 회원 여부 응답 추가

### DIFF
--- a/src/main/java/dgu/sw/domain/auth/controller/AuthController.java
+++ b/src/main/java/dgu/sw/domain/auth/controller/AuthController.java
@@ -1,15 +1,13 @@
 package dgu.sw.domain.auth.controller;
 
+import dgu.sw.domain.auth.dto.AuthDTO.AuthRequest.KakaoLoginRequest;
 import dgu.sw.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
 import dgu.sw.domain.auth.service.AuthService;
 import dgu.sw.global.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,9 +17,9 @@ public class AuthController {
 
     private final AuthService authService;
 
-    @PostMapping("/kakao/login/{code}")
-    @Operation(summary = "카카오 로그인 API", description = "카카오 로그인 API 입니다.")
-    public ApiResponse<AuthUserResponse> kakaoLogin(@PathVariable String code) {
-        return ApiResponse.onSuccess(authService.oAuthLogin(code));
+    @PostMapping("/kakao/login")
+    @Operation(summary = "카카오 로그인 API", description = "카카오 SDK access token 기반 로그인 API")
+    public ApiResponse<AuthUserResponse> kakaoLogin(@RequestBody KakaoLoginRequest request) {
+        return ApiResponse.onSuccess(authService.kakaoLoginWithAccessToken(request.getAccessToken()));
     }
 }

--- a/src/main/java/dgu/sw/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/dgu/sw/domain/auth/converter/AuthConverter.java
@@ -16,14 +16,15 @@ public class AuthConverter {
                 .build();
     }
 
-    public static AuthUserResponse toAuthUserResponse(User user, String accessToken, String refreshToken) {
-        return new AuthUserResponse(
-                user.getProvider().name(),
-                user.getEmail(),
-                user.getNickname(),
-                user.getProfileImage(),
-                accessToken,
-                refreshToken
-        );
+    public static AuthUserResponse toAuthUserResponse(User user, String accessToken, String refreshToken, boolean isNew) {
+        return AuthUserResponse.builder()
+                .provider(user.getProvider().name())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .profileImage(user.getProfileImage())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .isNew(isNew)
+                .build();
     }
 }

--- a/src/main/java/dgu/sw/domain/auth/dto/AuthDTO.java
+++ b/src/main/java/dgu/sw/domain/auth/dto/AuthDTO.java
@@ -13,6 +13,12 @@ public class AuthDTO {
         public static class AuthInfoRequest{
             private String email;
         }
+
+        @Getter
+        @NoArgsConstructor
+        public static class KakaoLoginRequest {
+            private String accessToken;
+        }
     }
 
     public static class AuthResponse {
@@ -77,6 +83,7 @@ public class AuthDTO {
             private String profileImage;
             private String accessToken;
             private String refreshToken;
+            private boolean isNew; // 신규 가입 여부
         }
     }
 }

--- a/src/main/java/dgu/sw/domain/auth/service/AuthService.java
+++ b/src/main/java/dgu/sw/domain/auth/service/AuthService.java
@@ -3,5 +3,5 @@ package dgu.sw.domain.auth.service;
 import dgu.sw.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
 
 public interface AuthService {
-    AuthUserResponse oAuthLogin (String accessCode);
+    AuthUserResponse kakaoLoginWithAccessToken(String accessToken);
 }

--- a/src/main/java/dgu/sw/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/auth/service/AuthServiceImpl.java
@@ -5,12 +5,15 @@ import dgu.sw.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
 import dgu.sw.domain.auth.dto.AuthUserProfile;
 import dgu.sw.domain.user.entity.User;
 import dgu.sw.domain.user.repository.UserRepository;
+import dgu.sw.global.config.redis.RedisUtil;
 import dgu.sw.global.security.JwtTokenProvider;
 import dgu.sw.global.security.OAuthProvider;
 import dgu.sw.global.security.OAuthUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -20,6 +23,7 @@ public class AuthServiceImpl implements AuthService {
     private final OAuthUtil oAuthUtil;
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RedisUtil redisUtil;
 
     /**
      * 카카오 로그인 처리
@@ -27,24 +31,27 @@ public class AuthServiceImpl implements AuthService {
      * - 기존 회원이면 로그인, 아니면 회원가입 후 JWT 발급
      */
     @Override
-    public AuthUserResponse oAuthLogin(String code) {
-        // 1. 카카오 액세스 토큰 요청
-        String accessToken = oAuthUtil.requestAccessToken(OAuthProvider.KAKAO, code);
-
-        // 2. 카카오 사용자 정보 요청
+    public AuthUserResponse kakaoLoginWithAccessToken(String accessToken) {
+        // 1. 카카오 사용자 정보 요청
         AuthUserProfile userProfile = oAuthUtil.requestUserProfile(OAuthProvider.KAKAO, accessToken);
 
-        // 3. DB에서 사용자 조회 또는 신규 회원가입
-        User user = userRepository.findByEmail(userProfile.getEmail())
-                .orElseGet(() -> registerNewUser(userProfile));
+        // 2. DB에서 기존 사용자 조회 또는 신규 회원가입
+        Optional<User> existingUser = userRepository.findByEmail(userProfile.getEmail());
+        boolean isNewUser = existingUser.isEmpty();
 
-        // 4. JWT AccessToken & RefreshToken 발급
+        User user = existingUser.orElseGet(() -> registerNewUser(userProfile));
+
+        // 3. JWT 발급
         String jwtAccessToken = jwtTokenProvider.generateAccessToken(user);
         String jwtRefreshToken = jwtTokenProvider.generateRefreshToken(user);
 
-        // 5. 응답 DTO 변환 후 반환
-        return AuthConverter.toAuthUserResponse(user, jwtAccessToken, jwtRefreshToken);
+        // Redis에 RefreshToken 저장
+        redisUtil.saveRefreshToken(user.getUserId().toString(), jwtRefreshToken);
+
+        // 4. 응답 DTO 변환 후 반환
+        return AuthConverter.toAuthUserResponse(user, jwtAccessToken, jwtRefreshToken, isNewUser);
     }
+
 
     /**
      * 카카오 신규 회원가입


### PR DESCRIPTION
## Related Issue 🍀
- #107 

<br>

## Key Changes 🔑
- 기존 인가코드 기반 카카오 로그인 방식 제거
- 카카오 SDK 방식 (accessToken 전달) 기반 로그인 로직으로 변경
- accessToken을 통해 사용자 정보 조회 후 회원 가입 or 로그인 처리
- JWT Access / Refresh Token 발급
- 응답 DTO에 'isNew' 필드 추가 → 신규 회원 여부 반환

<br>

## To Reviewers 🙏🏻
- 