### PR TITLE
[Feature] #106 - 네이버 로그인 구현

### DIFF
--- a/src/main/java/dgu/sw/domain/auth/controller/AuthController.java
+++ b/src/main/java/dgu/sw/domain/auth/controller/AuthController.java
@@ -1,6 +1,6 @@
 package dgu.sw.domain.auth.controller;
 
-import dgu.sw.domain.auth.dto.AuthDTO.AuthRequest.KakaoLoginRequest;
+import dgu.sw.domain.auth.dto.AuthDTO.AuthRequest.SocialLoginRequest;
 import dgu.sw.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
 import dgu.sw.domain.auth.service.AuthService;
 import dgu.sw.global.ApiResponse;
@@ -19,7 +19,13 @@ public class AuthController {
 
     @PostMapping("/kakao/login")
     @Operation(summary = "카카오 로그인 API", description = "카카오 SDK access token 기반 로그인 API")
-    public ApiResponse<AuthUserResponse> kakaoLogin(@RequestBody KakaoLoginRequest request) {
+    public ApiResponse<AuthUserResponse> kakaoLogin(@RequestBody SocialLoginRequest request) {
         return ApiResponse.onSuccess(authService.kakaoLoginWithAccessToken(request.getAccessToken()));
+    }
+
+    @PostMapping("/naver/login")
+    @Operation(summary = "네이버 로그인 API", description = "네이버 access token 기반 로그인 API")
+    public ApiResponse<AuthUserResponse> naverLogin(@RequestBody SocialLoginRequest request) {
+        return ApiResponse.onSuccess(authService.naverLoginWithAccessToken(request.getAccessToken()));
     }
 }

--- a/src/main/java/dgu/sw/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/dgu/sw/domain/auth/converter/AuthConverter.java
@@ -12,7 +12,7 @@ public class AuthConverter {
                 .email(profile.getEmail())
                 .nickname(profile.getNickname())
                 .profileImage(profile.getProfileImage())
-                .provider(OAuthProvider.KAKAO) // 카카오 로그인
+                .provider(profile.getProvider())
                 .build();
     }
 

--- a/src/main/java/dgu/sw/domain/auth/dto/AuthDTO.java
+++ b/src/main/java/dgu/sw/domain/auth/dto/AuthDTO.java
@@ -16,7 +16,7 @@ public class AuthDTO {
 
         @Getter
         @NoArgsConstructor
-        public static class KakaoLoginRequest {
+        public static class SocialLoginRequest {
             private String accessToken;
         }
     }

--- a/src/main/java/dgu/sw/domain/auth/service/AuthService.java
+++ b/src/main/java/dgu/sw/domain/auth/service/AuthService.java
@@ -4,4 +4,6 @@ import dgu.sw.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
 
 public interface AuthService {
     AuthUserResponse kakaoLoginWithAccessToken(String accessToken);
+    AuthUserResponse naverLoginWithAccessToken(String accessToken);
+
 }

--- a/src/main/java/dgu/sw/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/auth/service/AuthServiceImpl.java
@@ -53,6 +53,7 @@ public class AuthServiceImpl implements AuthService {
         // 1. 소셜 사용자 프로필 조회 (provider 기반)
         AuthUserProfile userProfile = oAuthUtil.requestUserProfile(provider, accessToken);
 
+
         // 2. 기존 회원 여부 확인
         Optional<User> existingUser = userRepository.findByEmail(userProfile.getEmail());
         boolean isNewUser = existingUser.isEmpty();
@@ -76,6 +77,7 @@ public class AuthServiceImpl implements AuthService {
      */
     private User registerNewUser(AuthUserProfile profile) {
         User newUser = AuthConverter.toUser(profile);
+        System.out.println(newUser.getProvider());
         return userRepository.save(newUser);
     }
 }

--- a/src/main/java/dgu/sw/global/security/OAuthUtil.java
+++ b/src/main/java/dgu/sw/global/security/OAuthUtil.java
@@ -124,7 +124,7 @@ public class OAuthUtil {
         try {
             JsonNode jsonNode = objectMapper.readTree(response.getBody()).get("response");
             String email = jsonNode.get("email").asText();
-            String nickname = jsonNode.get("nickname").asText();
+            String nickname = jsonNode.get("name").asText();
             String profileImage = jsonNode.get("profile_image").asText();
 
             return AuthUserProfile.builder()

--- a/src/main/java/dgu/sw/global/security/OAuthUtil.java
+++ b/src/main/java/dgu/sw/global/security/OAuthUtil.java
@@ -26,8 +26,14 @@ public class OAuthUtil {
     @Value("${oauth.kakao.redirect-uri}")
     private String kakaoRedirectUri;
 
-    public String requestAccessToken(OAuthProvider provider, String code) {
+    @Value("${oauth.naver.client-id}")
+    private String naverClientId;
 
+    @Value("${oauth.naver.client-secret}")
+    private String naverClientSecret;
+
+    public String requestAccessToken(OAuthProvider provider, String code) {
+        // 보통 SDK 방식에서는 호출되지 않음
         if (provider != OAuthProvider.KAKAO) {
             throw new OAuthException(ErrorStatus.OAUTH_UNSUPPORTED_PROVIDER);
         }
@@ -57,18 +63,27 @@ public class OAuthUtil {
     }
 
     public AuthUserProfile requestUserProfile(OAuthProvider provider, String accessToken) {
-        if (provider != OAuthProvider.KAKAO) {
-            throw new OAuthException(ErrorStatus.OAUTH_UNSUPPORTED_PROVIDER);
-        }
+        return switch (provider) {
+            case KAKAO -> requestKakaoUserProfile(accessToken);
+            case NAVER -> requestNaverUserProfile(accessToken);
+//            case GOOGLE -> requestGoogleUserProfile(accessToken);
+//            case APPLE -> requestAppleUserProfile(accessToken);
+            default -> throw new OAuthException(ErrorStatus.OAUTH_UNSUPPORTED_PROVIDER);
+        };
+    }
 
+    private AuthUserProfile requestKakaoUserProfile(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(accessToken);
-
         HttpEntity<String> request = new HttpEntity<>(headers);
-        ResponseEntity<String> response = restTemplate.exchange(OAuthConstants.KAKAO_PROFILE_URL, HttpMethod.GET, request, String.class);
+        ResponseEntity<String> response = restTemplate.exchange(
+                OAuthConstants.KAKAO_PROFILE_URL,
+                HttpMethod.GET,
+                request,
+                String.class
+        );
 
         if (response.getStatusCode() != HttpStatus.OK) {
-            System.out.println("카카오 프로필 응답 오류: " + response.getBody());
             throw new OAuthException(ErrorStatus.OAUTH_REQUEST_FAILED);
         }
 
@@ -76,16 +91,44 @@ public class OAuthUtil {
             JsonNode jsonNode = objectMapper.readTree(response.getBody());
             JsonNode kakaoAccount = jsonNode.get("kakao_account");
 
-            if (kakaoAccount == null || !kakaoAccount.has("email") || !kakaoAccount.has("profile")) {
-                throw new OAuthException(ErrorStatus.OAUTH_JSON_PARSE_ERROR);
-            }
-
             String email = kakaoAccount.get("email").asText();
             String nickname = kakaoAccount.get("profile").get("nickname").asText();
             String profileImage = kakaoAccount.get("profile").get("thumbnail_image_url").asText();
 
             return AuthUserProfile.builder()
                     .provider(OAuthProvider.KAKAO)
+                    .email(email)
+                    .nickname(nickname)
+                    .profileImage(profileImage)
+                    .build();
+        } catch (Exception e) {
+            throw new OAuthException(ErrorStatus.OAUTH_JSON_PARSE_ERROR);
+        }
+    }
+
+    private AuthUserProfile requestNaverUserProfile(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        ResponseEntity<String> response = restTemplate.exchange(
+                OAuthConstants.NAVER_PROFILE_URL,
+                HttpMethod.GET,
+                request,
+                String.class
+        );
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new OAuthException(ErrorStatus.OAUTH_REQUEST_FAILED);
+        }
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(response.getBody()).get("response");
+            String email = jsonNode.get("email").asText();
+            String nickname = jsonNode.get("nickname").asText();
+            String profileImage = jsonNode.get("profile_image").asText();
+
+            return AuthUserProfile.builder()
+                    .provider(OAuthProvider.NAVER)
                     .email(email)
                     .nickname(nickname)
                     .profileImage(profileImage)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,5 +35,10 @@ oauth:
     client-id: ${KAKAO_CLIENT_ID}
     redirect-uri: ${KAKAO_REDIRECT_URI}
 
+  naver:
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}
+    profile-url: https://openapi.naver.com/v1/nid/me
+
 REDIS_HOST: ${REDIS_URL}
 REDIS_PORT: ${REDIS_PORT}


### PR DESCRIPTION
## Related Issue 🍀
- #106 

<br>

## Key Changes 🔑
1. 네이버 OAuth 연동
- OAuthUtil에 requestNaverUserProfile 메서드 추가
- access token으로 사용자 정보 조회
- email, name, profileImage 등 정보 파싱

2. AuthService 통합 처리
- naverLoginWithAccessToken() 추가
- handleSocialLogin() 재사용하여 회원 등록 / 로그인 공통 처리
- AuthConverter.toUser()에서 provider 값을 KAKAO로 하드코딩하던 부분을 profile.getProvider()로 변경하여 동적 처리 가능하도록 수정 🚨

🔄 네이버 로그인 흐름
- 사용자에게 인증 URL 전달 후, code 발급받음
- code를 통해 네이버 access token 발급
- 클라이언트에서 access token을 서버로 전송
- 서버에서 사용자 정보 조회 후 로그인 / 회원가입 처리
- JWT Access/Refresh Token 반환

<br>

## To Reviewers 🙏🏻
- provider에 자꾸 KAKAO로만 들어가서 화가 났는데 provider 값을 항상 KAKAO로 넣었던 부분이 문제였다능