### PR TITLE
[Feature] #118 - 입사일 변경 API 구현 및 MyPageResponse에 Swagger용 @Schema 어노테이션 추가

### DIFF
--- a/src/main/java/dgu/sw/domain/user/controller/UserController.java
+++ b/src/main/java/dgu/sw/domain/user/controller/UserController.java
@@ -91,4 +91,14 @@ public class UserController {
     public ApiResponse<MyPageResponse> getMyPage(Authentication authentication) {
         return ApiResponse.onSuccess(userService.getMyPage(authentication.getName()));
     }
+
+    @PatchMapping("/join-date")
+    @Operation(summary = "입사일 변경 API", description = "사용자의 입사일을 수정합니다.")
+    public ApiResponse<UpdateJoinDateResponse> updateJoinDate(
+            Authentication authentication,
+            @RequestBody @Valid UpdateJoinDateRequest request
+    ) {
+        UpdateJoinDateResponse response = userService.updateJoinDate(authentication.getName(), request.getJoinDate());
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/dgu/sw/domain/user/dto/UserDTO.java
+++ b/src/main/java/dgu/sw/domain/user/dto/UserDTO.java
@@ -134,10 +134,16 @@ public class UserDTO {
         @NoArgsConstructor
         @AllArgsConstructor
         public static class MyPageResponse {
+            @Schema(description = "유저 이름", example = "김동국")
             private String nickname;
+
+            @Schema(description = "유저 이메일", example = "2025123456@dgu.ac.kr")
             private String email;
+
+            @Schema(description = "입사일", example = "2025-03-14")
             private LocalDate joinDate;
         }
+
 
         @Getter
         @Builder

--- a/src/main/java/dgu/sw/domain/user/dto/UserDTO.java
+++ b/src/main/java/dgu/sw/domain/user/dto/UserDTO.java
@@ -93,6 +93,14 @@ public class UserDTO {
             @Schema(description = "새 비밀번호 확인", example = "newpassword123")
             private String confirmPassword;
         }
+
+
+        @Getter
+        public static class UpdateJoinDateRequest {
+            @NotNull
+            @Schema(description = "변경할 입사일", example = "2025-03-14")
+            private LocalDate joinDate;
+        }
     }
 
     public static class UserResponse {
@@ -129,6 +137,15 @@ public class UserDTO {
             private String nickname;
             private String email;
             private LocalDate joinDate;
+        }
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        @NoArgsConstructor
+        public static class UpdateJoinDateResponse {
+            @Schema(description = "변경된 입사일", example = "2025-03-14")
+            private LocalDate updatedJoinDate;
         }
     }
 }

--- a/src/main/java/dgu/sw/domain/user/entity/User.java
+++ b/src/main/java/dgu/sw/domain/user/entity/User.java
@@ -45,4 +45,8 @@ public class User {
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
+
+    public void updateJoinDate(LocalDate newDate) {
+        this.joinDate = newDate;
+    }
 }

--- a/src/main/java/dgu/sw/domain/user/service/UserService.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserService.java
@@ -5,6 +5,8 @@ import dgu.sw.domain.user.dto.UserDTO.UserRequest.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import java.time.LocalDate;
+
 public interface UserService {
     SignUpResponse signUp(SignUpRequest request);
 
@@ -30,4 +32,6 @@ public interface UserService {
     void resetPassword(PasswordResetRequest request);
 
     MyPageResponse getMyPage(String userId);
+
+    UpdateJoinDateResponse updateJoinDate(String userId, LocalDate joinDate);
 }

--- a/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
@@ -1,6 +1,7 @@
 package dgu.sw.domain.user.service;
 
 import dgu.sw.domain.user.converter.UserConverter;
+import dgu.sw.domain.user.dto.UserDTO.UserResponse.UpdateJoinDateResponse;
 import dgu.sw.domain.user.dto.UserDTO.UserResponse.MyPageResponse;
 import dgu.sw.domain.user.dto.UserDTO.UserResponse.SignInResponse;
 import dgu.sw.domain.user.entity.User;
@@ -25,6 +26,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import dgu.sw.global.config.util.EmailService;
+
+import java.time.LocalDate;
 
 @Slf4j
 @Service
@@ -261,5 +264,18 @@ public class UserServiceImpl implements UserService {
     public MyPageResponse getMyPage(String userId) {
         User user = userRepository.findByUserId(Long.valueOf(userId));
         return UserConverter.toMyPageResponse(user);
+    }
+
+    @Override
+    public UpdateJoinDateResponse updateJoinDate(String userId, LocalDate joinDate) {
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+
+        user.updateJoinDate(joinDate);
+        userRepository.save(user);
+
+        return UpdateJoinDateResponse.builder()
+                .updatedJoinDate(user.getJoinDate())
+                .build();
     }
 }


### PR DESCRIPTION
## Related Issue 🍀
- #118 

<br>

## Key Changes 🔑
- UpdateJoinDateRequest, UpdateJoinDateResponse DTO 정의
- UserController에 입사일 변경 핸들러 추가
- UserServiceImpl에서 입사일 업데이트 로직 구현 (updateJoinDate())
- MyPageResponse에 Swagger용 @Schema 어노테이션 추가

<br>

## To Reviewers 🙏🏻
- 