### PR TITLE
[Feature] #126 - 로그아웃 및 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/dgu/sw/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/auth/service/AuthServiceImpl.java
@@ -85,7 +85,6 @@ public class AuthServiceImpl implements AuthService {
      */
     private User registerNewUser(AuthUserProfile profile) {
         User newUser = AuthConverter.toUser(profile);
-        System.out.println(newUser.getProvider());
         return userRepository.save(newUser);
     }
 }

--- a/src/main/java/dgu/sw/domain/user/controller/UserController.java
+++ b/src/main/java/dgu/sw/domain/user/controller/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
     }
 
     @PostMapping("/signout")
-    @Operation(summary = "로그아웃 API", description = "로그아웃 API 입니다.")
+    @Operation(summary = "로그아웃 API", description = "일반 및 소셜 통합 로그아웃 API입니다.")
     public ApiResponse<String> signOut(HttpServletRequest request, HttpServletResponse response) {
         userService.signOut(request, response);
         return ApiResponse.onSuccess("로그아웃 성공");
@@ -100,5 +100,12 @@ public class UserController {
     ) {
         UpdateJoinDateResponse response = userService.updateJoinDate(authentication.getName(), request.getJoinDate());
         return ApiResponse.onSuccess(response);
+    }
+
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원탈퇴 API", description = "일반 및 소셜 통합 회원탈퇴 API입니다.")
+    public ApiResponse<String> withdraw(HttpServletRequest request) {
+        userService.withdraw(request);
+        return ApiResponse.onSuccess("회원탈퇴 완료");
     }
 }

--- a/src/main/java/dgu/sw/domain/user/service/UserService.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserService.java
@@ -34,4 +34,6 @@ public interface UserService {
     MyPageResponse getMyPage(String userId);
 
     UpdateJoinDateResponse updateJoinDate(String userId, LocalDate joinDate);
+
+    void withdraw(HttpServletRequest request);
 }

--- a/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
@@ -10,6 +10,7 @@ import dgu.sw.global.security.JwtTokenProvider;
 import dgu.sw.global.security.JwtUtil;
 import dgu.sw.global.config.redis.RedisUtil;
 import dgu.sw.global.exception.UserException;
+import dgu.sw.global.security.OAuthUtil;
 import dgu.sw.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,8 +41,8 @@ public class UserServiceImpl implements UserService {
     private final RedisUtil redisUtil;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-
     private final EmailService emailService;
+    private final OAuthUtil oAuthUtil;
 
     /**
      * 회원가입
@@ -105,6 +106,14 @@ public class UserServiceImpl implements UserService {
         // Redis에서 RefreshToken 삭제
         String userId = String.valueOf(jwtUtil.extractUserId(accessToken));
         redisUtil.deleteRefreshToken(userId);
+
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+
+        // 소셜 로그인이면 외부 플랫폼 로그아웃 처리
+        if (user.getProvider() != null) {
+            oAuthUtil.logoutFromProvider(user.getProvider());
+        }
     }
 
     /**
@@ -277,5 +286,34 @@ public class UserServiceImpl implements UserService {
         return UpdateJoinDateResponse.builder()
                 .updatedJoinDate(user.getJoinDate())
                 .build();
+    }
+
+    @Override
+    public void withdraw(HttpServletRequest request) {
+        String accessToken = resolveToken(request);
+        if (accessToken == null) {
+            throw new UserException(ErrorStatus.TOKEN_NOT_FOUND);
+        }
+
+        Long userId = jwtUtil.extractUserId(accessToken);
+        if (userId == null) {
+            throw new UserException(ErrorStatus.USER_NOT_FOUND);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+
+        // 로그아웃 처리 (블랙리스트 등록 + Refresh 삭제)
+        Long expiration = jwtUtil.getExpiration(accessToken);
+        redisUtil.addTokenToBlacklist(accessToken, expiration);
+        redisUtil.deleteRefreshToken(String.valueOf(userId));
+
+        // 소셜 로그인이면 외부 로그아웃
+        if (user.getProvider() != null) {
+            oAuthUtil.logoutFromProvider(user.getProvider());
+        }
+
+        // DB에서 삭제
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/dgu/sw/global/security/OAuthUtil.java
+++ b/src/main/java/dgu/sw/global/security/OAuthUtil.java
@@ -137,4 +137,21 @@ public class OAuthUtil {
             throw new OAuthException(ErrorStatus.OAUTH_JSON_PARSE_ERROR);
         }
     }
+
+    public void logoutFromProvider(OAuthProvider provider) {
+        switch (provider) {
+            case KAKAO -> logoutFromKakao();
+            case NAVER -> logoutFromNaver();
+            default -> throw new OAuthException(ErrorStatus.OAUTH_UNSUPPORTED_PROVIDER);
+        }
+    }
+
+    private void logoutFromKakao() {
+        // 실제 구현 시 사용자 accessToken 등을 활용하여 로그아웃 API 호출 가능
+        System.out.println("👉 카카오 로그아웃 요청 완료 (추후 SDK 연동 필요)");
+    }
+
+    private void logoutFromNaver() {
+        System.out.println("👉 네이버 로그아웃 요청 완료 (추후 SDK 연동 필요)");
+    }
 }


### PR DESCRIPTION
## Related Issue 🍀
- #126 

<br>

## Key Changes 🔑
- 로그인 후 발급된 AccessToken을 블랙리스트 등록하여 로그아웃 처리
- Redis에 저장된 RefreshToken 삭제
- 소셜 로그인 사용자의 경우, OAuthUtil.logoutFromProvider() 통해 카카오/네이버 로그아웃 처리
- 회원탈퇴 시 사용자 정보 DB에서 삭제

<br>

## To Reviewers 🙏🏻
- 추후 실제 플랫폼 로그아웃 연동 시 OAuthUtil 내 메서드 확장 예정