### PR TITLE
[Refactor] #135 - 에러 처리 코드 리팩토링

### DIFF
--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
@@ -15,6 +15,7 @@ import dgu.sw.domain.quiz.repository.QuizRepository;
 import dgu.sw.domain.user.entity.User;
 import dgu.sw.domain.user.repository.UserRepository;
 import dgu.sw.global.exception.QuizException;
+import dgu.sw.global.exception.MockTestException;
 import dgu.sw.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -70,7 +71,7 @@ public class MockTestServiceImpl implements MockTestService {
     @Transactional
     public SubmitMockTestResponse submitMockTest(Long mockTestId, SubmitMockTestRequest request) {
         MockTest mockTest = mockTestRepository.findById(mockTestId)
-                .orElseThrow(() -> new QuizException(ErrorStatus.QUIZ_NOT_FOUND));
+                .orElseThrow(() -> new MockTestException(ErrorStatus.MOCK_TEST_NOT_FOUND));
 
         List<MockTestQuiz> mockTestQuizzes = mockTestQuizRepository.findByMockTest_MockTestId(mockTestId);
 
@@ -79,7 +80,7 @@ public class MockTestServiceImpl implements MockTestService {
             MockTestQuiz quizRecord = mockTestQuizzes.stream()
                     .filter(mtq -> mtq.getQuiz().getQuizId().equals(answer.getQuizId()))
                     .findFirst()
-                    .orElseThrow(() -> new QuizException(ErrorStatus.QUIZ_NOT_FOUND));
+                    .orElseThrow(() -> new MockTestException(ErrorStatus.MOCK_TEST_QUIZ_NOT_FOUND));
 
             boolean isCorrect = quizRecord.getQuiz().getAnswer().equals(answer.getSelectedAnswer());
             quizRecord.updateCorrect(isCorrect);
@@ -121,7 +122,7 @@ public class MockTestServiceImpl implements MockTestService {
     public MockTestResultResponse getMockTestResult(Long mockTestId) {
         // 1. 모의고사 정보 가져오기
         MockTest mockTest = mockTestRepository.findById(mockTestId)
-                .orElseThrow(() -> new QuizException(ErrorStatus.MOCK_TEST_NOT_COMPLETED));
+                .orElseThrow(() -> new MockTestException(ErrorStatus.MOCK_TEST_NOT_FOUND));
 
         List<MockTestQuiz> mockTestQuizzes = mockTestQuizRepository.findByMockTest_MockTestId(mockTestId);
 
@@ -207,7 +208,7 @@ public class MockTestServiceImpl implements MockTestService {
                 .findTopByUser_UserIdAndIsCompletedTrueOrderByCreatedDateDesc(uid);
 
         MockTest mockTest = previousMockTestOpt
-                .orElseThrow(() -> new QuizException(ErrorStatus.MOCK_TEST_NOT_FOUND));
+                .orElseThrow(() -> new MockTestException(ErrorStatus.MOCK_TEST_NOT_FOUND));
 
         return getMockTestResult(mockTest.getMockTestId());
     }

--- a/src/main/java/dgu/sw/global/exception/MockTestException.java
+++ b/src/main/java/dgu/sw/global/exception/MockTestException.java
@@ -1,0 +1,10 @@
+package dgu.sw.global.exception;
+
+import dgu.sw.global.status.ErrorStatus;
+
+public class MockTestException extends GeneralException {
+
+    public MockTestException(ErrorStatus code) {
+        super(code);
+    }
+}

--- a/src/main/java/dgu/sw/global/status/ErrorStatus.java
+++ b/src/main/java/dgu/sw/global/status/ErrorStatus.java
@@ -71,7 +71,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 모의고사 관련 에러
     MOCK_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "MOCK4041", "해당 모의고사를 찾을 수 없습니다."),
-    MOCK_TEST_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "MOCK4001", "이미 제출된 모의고사입니다."),
+    // MOCK_TEST_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "MOCK4001", "이미 제출된 모의고사입니다."),
     MOCK_TEST_QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "MOCK4042", "해당 모의고사 문제를 찾을 수 없습니다."),
     MOCK_TEST_USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MOCK4002", "해당 사용자의 모의고사를 찾을 수 없습니다.");
 

--- a/src/main/java/dgu/sw/global/status/ErrorStatus.java
+++ b/src/main/java/dgu/sw/global/status/ErrorStatus.java
@@ -57,6 +57,10 @@ public enum ErrorStatus implements BaseErrorCode {
     OAUTH_JSON_PARSE_ERROR(HttpStatus.BAD_REQUEST, "OAUTH4003", "OAuth 응답 파싱에 실패했습니다."),
     OAUTH_ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "OAUTH4004", "OAuth 인증에 실패했습니다."),
     SOCIAL_PROVIDER_CONFLICT(HttpStatus.CONFLICT, "AUTH4004", "다른 소셜 로그인으로 이미 가입된 이메일입니다."),
+    OAUTH_ACCESS_TOKEN_MISSING(HttpStatus.BAD_REQUEST, "OAUTH4005", "Access Token이 누락되었습니다."),
+    OAUTH_USERINFO_FETCH_FAILED(HttpStatus.UNAUTHORIZED, "OAUTH4006", "소셜 사용자 정보를 가져오는 데 실패했습니다."),
+    OAUTH_EMAIL_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "OAUTH4007", "소셜 로그인에 이메일 정보가 포함되어 있지 않습니다."),
+    OAUTH_REFRESH_TOKEN_SAVE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "OAUTH5001", "Redis에 Refresh Token 저장에 실패했습니다."),
 
     // 인증코드 관련 에러
     CODE_EXPIRED(HttpStatus.BAD_REQUEST, "USER4009", "인증코드가 만료되었습니다."),

--- a/src/main/java/dgu/sw/global/status/ErrorStatus.java
+++ b/src/main/java/dgu/sw/global/status/ErrorStatus.java
@@ -66,8 +66,10 @@ public enum ErrorStatus implements BaseErrorCode {
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "USER4011", "새 비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 
     // 모의고사 관련 에러
-    MOCK_TEST_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MOCK4001", "아직 제출되지 않은 모의고사입니다."),
-    MOCK_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "MOCK4002", "해당 모의고사를 찾을 수 없습니다.");
+    MOCK_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "MOCK4041", "해당 모의고사를 찾을 수 없습니다."),
+    MOCK_TEST_ALREADY_SUBMITTED(HttpStatus.BAD_REQUEST, "MOCK4001", "이미 제출된 모의고사입니다."),
+    MOCK_TEST_QUIZ_NOT_FOUND(HttpStatus.NOT_FOUND, "MOCK4042", "해당 모의고사 문제를 찾을 수 없습니다."),
+    MOCK_TEST_USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MOCK4002", "해당 사용자의 모의고사를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## Related Issue 🍀
- close #135 
<br>

## Key Changes 🔑
### **[MockTest 관련]**
1. 모의고사 도메인 전용 에러 코드 분리
  - 기존에는 퀴즈 도메인의 에러 코드를 모의고사에서 사용하고 있었음
  - MOCK_TEST_NOT_FOUND, MOCK_TEST_ALREADY_SUBMITTED, MOCK_TEST_QUIZ_NOT_FOUND, MOCK_TEST_USER_NOT_FOUND 등 모의고사 전용 ErrorStatus 항목을 ErrorStatus enum에 새로 추가

2. MockTestException 클래스 생성
  - QuizException이 아닌 모의고사 도메인 전용 예외 처리 클래스로 MockTestException 생성

3. 1,2에 기반하여 MockTestServiceImpl 내부 에러 처리 개선
  - 기존 new QuizException(...) 모두 new MockTestException(...) 으로 변경

### **[OAuth 관련]**

- 소셜 로그인 처리 내부에서 발생하는 예외 상황을 더 세세하게 구분하도록 ErrorStatus 리팩토링
- AuthServiceImpl 내 handleSocialLogin() 메서드에서 아래 조건에 따라 에러 코드 반환하도록 수정
  - OAUTH_REQUEST_FAILED: 소셜 서버로부터 사용자 프로필 요청 실패 시
  - OAUTH_JSON_PARSE_ERROR: 응답 파싱 실패 시
  - SOCIAL_PROVIDER_CONFLICT: 이미 다른 provider로 가입된 계정으로 로그인 시도 시

<br>

## To Reviewers 🙏🏻
- 