### PR TITLE
[Feature] #141 - 모의고사 회차별 결과 조회 API 구현

### DIFF
--- a/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
+++ b/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/mockTest")
@@ -36,17 +38,10 @@ public class MockTestController {
         return ApiResponse.onSuccess(response);
     }
 
-    @GetMapping("/{mockTestId}/result")
-    @Operation(summary = "모의고사 결과 조회", description = "모의고사 결과를 반환합니다.")
-    public ApiResponse<MockTestResultResponse> getMockTestResult(@PathVariable Long mockTestId) {
-        MockTestResultResponse response = mockTestService.getMockTestResult(mockTestId);
-        return ApiResponse.onSuccess(response);
-    }
-
-    @GetMapping("/previous/result")
-    @Operation(summary = "이전 모의고사 결과 조회", description = "가장 최근에 완료한 이전 모의고사 결과를 조회합니다.")
-    public ApiResponse<MockTestResultResponse> getPreviousMockTestResult(Authentication authentication) {
-        MockTestResultResponse response = mockTestService.getPreviousMockTestResult(authentication.getName());
+    @GetMapping("/result/all")
+    @Operation(summary = "전체 모의고사 결과 조회", description = "해당 사용자가 완료한 모든 모의고사 결과를 반환합니다.")
+    public ApiResponse<List<MockTestResultResponse>> getAllMockTestResults(Authentication authentication) {
+        List<MockTestResultResponse> response = mockTestService.getAllMockTestResults(authentication.getName());
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
+++ b/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
@@ -16,7 +16,7 @@ import java.util.stream.Collectors;
 public class MockTestConverter {
     public static CreateMockTestResponse toCreateMockTestResponse(MockTest mockTest, List<MockTestQuiz> mockTestQuizzes) {
         List<MockTestQuestionResponse> quizResponses = mockTestQuizzes.stream()
-                .map(mtq -> new MockTestQuestionResponse(mtq.getQuiz().getQuizId(), mtq.getQuiz().getQuestion()))
+                .map(mtq -> new MockTestQuestionResponse(mtq.getQuiz().getQuizId(), mtq.getQuiz().getQuestion(), mtq.getQuiz().getQuestionDetail()))
                 .collect(Collectors.toList());
 
         return CreateMockTestResponse.builder()

--- a/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
+++ b/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
@@ -1,5 +1,6 @@
 package dgu.sw.domain.quiz.converter;
 
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.MockTestResultResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmittedQuizResult;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestResponse;
@@ -46,6 +47,27 @@ public class MockTestConverter {
                 .correctCount(mockTest.getCorrectCount())
                 .topPercentile(mockTest.getTopPercentile())
                 .results(results)
+                .build();
+    }
+
+    public static MockTestResultResponse toMockTestResultResponse(
+            MockTest mockTest,
+            int attemptCount,
+            int score,
+            int scoreChange,
+            double topPercentileChange,
+            List<MockTestResultResponse.CategoryResult> categoryResults,
+            List<MockTestResultResponse.MockTestQuestionResult> questionResults
+    ) {
+        return MockTestResultResponse.builder()
+                .mockTestId(mockTest.getMockTestId())
+                .attemptCount(attemptCount)
+                .score(score)
+                .scoreChange(scoreChange)
+                .topPercentile(mockTest.getTopPercentile())
+                .topPercentileChange(topPercentileChange)
+                .categoryResults(categoryResults)
+                .questionResults(questionResults)
                 .build();
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
+++ b/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
@@ -52,6 +52,7 @@ public class MockTestDTO {
         public static class MockTestQuestionResponse {
             private Long quizId;
             private String question;
+            private String questionDetail;
         }
 
         @Getter

--- a/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
+++ b/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
@@ -27,5 +27,5 @@ public interface MockTestRepository extends JpaRepository<MockTest, Long> {
 
     List<MockTest> findByUser_UserIdAndMockTestIdLessThan(Long userId, Long mockTestId);
 
-    Optional<MockTest> findTopByUser_UserIdAndIsCompletedTrueOrderByCreatedDateDesc(Long userId);
+    List<MockTest> findByUser_UserIdAndIsCompletedTrueOrderByMockTestIdAsc(Long userId);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
@@ -5,9 +5,10 @@ import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestRespons
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
 
+import java.util.List;
+
 public interface MockTestService {
     CreateMockTestResponse startMockTest(String userId);
     SubmitMockTestResponse submitMockTest(Long mockTestId, SubmitMockTestRequest request);
-    MockTestResultResponse getMockTestResult(Long mockTestId);
-    MockTestResultResponse getPreviousMockTestResult(String userId);
+    List<MockTestResultResponse> getAllMockTestResults(String userId);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
@@ -118,98 +118,73 @@ public class MockTestServiceImpl implements MockTestService {
     }
 
     @Override
-    public MockTestResultResponse getMockTestResult(Long mockTestId) {
-        // 1. 모의고사 정보 가져오기
-        MockTest mockTest = mockTestRepository.findById(mockTestId)
-                .orElseThrow(() -> new QuizException(ErrorStatus.MOCK_TEST_NOT_COMPLETED));
-
-        List<MockTestQuiz> mockTestQuizzes = mockTestQuizRepository.findByMockTest_MockTestId(mockTestId);
-
-        // 2. 전체 문제 정보 가공
-        List<MockTestQuestionResult> questionResults = mockTestQuizzes.stream()
-                .map(mtq -> MockTestResultResponse.MockTestQuestionResult.builder()
-                        .quizId(mtq.getQuiz().getQuizId())
-                        .category(mtq.getQuiz().getCategory())
-                        .question(mtq.getQuiz().getQuestion())
-                        .isCorrect(mtq.isCorrect())
-                        .build())
-                .collect(Collectors.toList());
-
-        // 3. 카테고리별 정답 개수 계산
-        Map<String, Long> totalQuestionsByCategory = mockTestQuizzes.stream()
-                .collect(Collectors.groupingBy(mtq -> mtq.getQuiz().getCategory(), Collectors.counting()));
-
-        Map<String, Long> correctQuestionsByCategory = mockTestQuizzes.stream()
-                .filter(MockTestQuiz::isCorrect)
-                .collect(Collectors.groupingBy(mtq -> mtq.getQuiz().getCategory(), Collectors.counting()));
-
-        List<MockTestResultResponse.CategoryResult> categoryResults = totalQuestionsByCategory.entrySet().stream()
-                .map(entry -> MockTestResultResponse.CategoryResult.builder()
-                        .category(entry.getKey())
-                        .correctCount(correctQuestionsByCategory.getOrDefault(entry.getKey(), 0L).intValue())
-                        .totalCount(entry.getValue().intValue())
-                        .build())
-                .collect(Collectors.toList());
-
-        // 4. 해당 모의고사가 몇 번째인지 계산
-        List<MockTest> userMockTests = mockTestRepository.findByUser_UserIdOrderByCreatedDateAsc(mockTest.getUser().getUserId());
-        int attemptCount = userMockTests.indexOf(mockTest) + 1; // 1부터 시작하는 순서
-
-        // 현재 점수 계산
-        int score = (int) ((double) mockTest.getCorrectCount() / mockTestQuizzes.size() * 100);
-
-        // 현재 모의고사 정보
-        Long currentMockTestId = mockTest.getMockTestId();
-        Long userId = mockTest.getUser().getUserId();
-
-        // 현재 모의고사를 푼 유저가 푼 mockTestId 중 현재 mockTestId보다 작은 것들 중 가장 큰 것
-        Optional<MockTest> previousMockTestOpt = mockTestRepository.findTopByUser_UserIdAndMockTestIdLessThanOrderByMockTestIdDesc(userId, currentMockTestId);
-
-        // 이전 모의고사 점수 계산
-        int scoreChange = 0;
-
-        if (previousMockTestOpt.isPresent()) {
-            MockTest previousMockTest = previousMockTestOpt.get();
-            List<MockTestQuiz> previousQuizzes = mockTestQuizRepository.findByMockTest_MockTestId(previousMockTest.getMockTestId());
-            int previousScore = previousQuizzes.size() > 0
-                    ? (int) ((double) previousMockTest.getCorrectCount() / previousQuizzes.size() * 100)
-                    : 0;
-            scoreChange = score - previousScore;
-        }
-
-        // 상위 퍼센트 계산 (점수가 높을수록 0에 가까워짐)
-        double topPercentile = mockTest.getTopPercentile();
-        double previousTopPercentile = previousMockTestOpt
-                .map(MockTest::getTopPercentile)
-                .orElse(topPercentile);
-
-        double topPercentileChange = previousTopPercentile - topPercentile;
-
-        // 7. 최종 결과 반환
-        return MockTestResultResponse.builder()
-                .mockTestId(mockTestId)
-                .score(score)
-                .attemptCount(attemptCount)
-                .scoreChange(scoreChange)
-                .topPercentile(topPercentile)
-                .topPercentileChange(topPercentileChange)
-                .categoryResults(categoryResults)
-                .questionResults(questionResults)
-                .build();
-    }
-
-    @Override
-    public MockTestResultResponse getPreviousMockTestResult(String userId) {
+    public List<MockTestResultResponse> getAllMockTestResults(String userId) {
         Long uid = Long.valueOf(userId);
 
-        // 유저가 푼 가장 최근(제일 마지막) 이전 모의고사
-        Optional<MockTest> previousMockTestOpt = mockTestRepository
-                .findTopByUser_UserIdAndIsCompletedTrueOrderByCreatedDateDesc(uid);
+        // 사용자의 모든 완료된 모의고사 조회 (정렬 포함)
+        List<MockTest> mockTests = mockTestRepository
+                .findByUser_UserIdAndIsCompletedTrueOrderByMockTestIdAsc(uid);
 
-        MockTest mockTest = previousMockTestOpt
-                .orElseThrow(() -> new QuizException(ErrorStatus.MOCK_TEST_NOT_FOUND));
+        List<MockTestResultResponse> results = mockTests.stream().map(mockTest -> {
+            Long mockTestId = mockTest.getMockTestId();
+            List<MockTestQuiz> quizzes = mockTestQuizRepository.findByMockTest_MockTestId(mockTestId);
 
-        return getMockTestResult(mockTest.getMockTestId());
+            // 카테고리별 정답 수 계산
+            Map<String, Long> totalByCategory = quizzes.stream()
+                    .collect(Collectors.groupingBy(q -> q.getQuiz().getCategory(), Collectors.counting()));
+
+            Map<String, Long> correctByCategory = quizzes.stream()
+                    .filter(MockTestQuiz::isCorrect)
+                    .collect(Collectors.groupingBy(q -> q.getQuiz().getCategory(), Collectors.counting()));
+
+            List<MockTestResultResponse.CategoryResult> categoryResults = totalByCategory.entrySet().stream()
+                    .map(entry -> MockTestResultResponse.CategoryResult.builder()
+                            .category(entry.getKey())
+                            .totalCount(entry.getValue().intValue())
+                            .correctCount(correctByCategory.getOrDefault(entry.getKey(), 0L).intValue())
+                            .build())
+                    .collect(Collectors.toList());
+
+            // 문제별 결과
+            List<MockTestResultResponse.MockTestQuestionResult> questionResults = quizzes.stream()
+                    .map(q -> MockTestResultResponse.MockTestQuestionResult.builder()
+                            .quizId(q.getQuiz().getQuizId())
+                            .category(q.getQuiz().getCategory())
+                            .question(q.getQuiz().getQuestion())
+                            .isCorrect(q.isCorrect())
+                            .build())
+                    .collect(Collectors.toList());
+
+            // 회차 정보 (몇 번째인지)
+            int attemptCount = mockTests.indexOf(mockTest) + 1;
+
+            // 점수
+            int score = (int) ((double) mockTest.getCorrectCount() / quizzes.size() * 100);
+
+            // 이전 모의고사 점수 및 퍼센트 변화 계산
+            int scoreChange = 0;
+            double topPercentileChange = 0.0;
+
+            if (attemptCount > 1) {
+                MockTest previous = mockTests.get(attemptCount - 2);
+                List<MockTestQuiz> prevQuizzes = mockTestQuizRepository.findByMockTest_MockTestId(previous.getMockTestId());
+                int previousScore = (int) ((double) previous.getCorrectCount() / prevQuizzes.size() * 100);
+                scoreChange = score - previousScore;
+                topPercentileChange = previous.getTopPercentile() - mockTest.getTopPercentile();
+            }
+
+            return MockTestConverter.toMockTestResultResponse(
+                    mockTest,
+                    attemptCount,
+                    score,
+                    scoreChange,
+                    topPercentileChange,
+                    categoryResults,
+                    questionResults
+            );
+
+        }).collect(Collectors.toList());
+
+        return results;
     }
-
 }


### PR DESCRIPTION
## Related Issue 🍀
- #141 

<br>

## Key Changes 🔑
- 완료된 모의고사가 여러 개일 때, 전체 모의고사를 리스트에 회차별로 반환
- 점수 및 등락률, 카테고리별 정답률 계산
- MockTestRepository에 쿼리 메서드
- findByUser_UserIdAndIsCompletedTrueOrderByMockTestIdAsc(Long userId) 추가
- 기존의 getPreviousMockTestResult 제거
- ++ 모의고사 생성 후 response에 퀴즈 detail 내용 추가!

<br>

## To Reviewers 🙏🏻
- 