### PR TITLE
[Bug] #156 - 퀴즈 메인 정보 조회 시 가장 최근 모의고사 데이터 불일치 해결

### DIFF
--- a/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
+++ b/src/main/java/dgu/sw/domain/quiz/converter/MockTestConverter.java
@@ -21,7 +21,7 @@ public class MockTestConverter {
 
         return CreateMockTestResponse.builder()
                 .mockTestId(mockTest.getMockTestId())
-                .createdDate(mockTest.getCreatedDate())
+                .createdAt(mockTest.getCreatedAt())
                 .isCompleted(mockTest.isCompleted())
                 .correctCount(mockTest.getCorrectCount())
                 .quizzes(quizResponses)

--- a/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
+++ b/src/main/java/dgu/sw/domain/quiz/dto/MockTestDTO.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public class MockTestDTO {
@@ -40,7 +40,7 @@ public class MockTestDTO {
         @Builder
         public static class CreateMockTestResponse {
             private Long mockTestId;
-            private LocalDate createdDate;
+            private LocalDateTime createdAt;
             private boolean isCompleted;
             private int correctCount;
             private List<MockTestQuestionResponse> quizzes;

--- a/src/main/java/dgu/sw/domain/quiz/entity/MockTest.java
+++ b/src/main/java/dgu/sw/domain/quiz/entity/MockTest.java
@@ -1,6 +1,7 @@
 package dgu.sw.domain.quiz.entity;
 
 import dgu.sw.domain.user.entity.User;
+import dgu.sw.global.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,7 +14,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Table(name = "mockTest")
-public class MockTest {
+public class MockTest extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long mockTestId;
@@ -21,8 +22,6 @@ public class MockTest {
     @ManyToOne
     @JoinColumn(name = "userId")
     private User user;
-
-    private LocalDate createdDate;
 
     private boolean isCompleted; // 다 풀었는지 여부
 

--- a/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
+++ b/src/main/java/dgu/sw/domain/quiz/repository/MockTestRepository.java
@@ -12,15 +12,13 @@ import java.util.Optional;
 
 @Repository
 public interface MockTestRepository extends JpaRepository<MockTest, Long> {
-    MockTest findTopByUser_UserIdOrderByCreatedDateDesc(Long userId);
     @Query("SELECT COUNT(me) FROM MockTest me WHERE me.isCompleted = true")
     long countCompletedExams();
 
     @Query("SELECT COUNT(me) FROM MockTest me WHERE me.correctCount > :score")
     long countByCorrectCountGreaterThan(@Param("score") int score);
 
-    List<MockTest> findByUser_UserIdOrderByCreatedDateAsc(Long userId);
-
+    Optional<MockTest> findTopByUser_UserIdOrderByCreatedAtDesc(Long userId);
     List<MockTest> findAllByIsCompletedTrue();
 
     Optional<MockTest> findTopByUser_UserIdAndMockTestIdLessThanOrderByMockTestIdDesc(Long userId, Long mockTestId);

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
@@ -46,7 +46,6 @@ public class MockTestServiceImpl implements MockTestService {
         // 모의고사 생성
         MockTest mockTest = MockTest.builder()
                 .user(user)
-                .createdDate(LocalDate.now())
                 .isCompleted(false)
                 .correctCount(0)
                 .build();

--- a/src/main/java/dgu/sw/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/QuizServiceImpl.java
@@ -289,7 +289,7 @@ public class QuizServiceImpl implements QuizService {
         double progressRate = (double) userSolvedCount / totalQuizCount * 100;
 
         // 최근 모의고사 점수
-        MockTest recentExam = mockTestRepository.findTopByUser_UserIdOrderByCreatedDateDesc(uid);
+        MockTest recentExam = mockTestRepository.findTopByUser_UserIdOrderByCreatedAtDesc(uid).orElse(null);
         Integer recentScore = recentExam != null ? recentExam.getCorrectCount() * 10 : null;
 
         // 상위 % 계산

--- a/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
@@ -94,7 +94,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void signOut(HttpServletRequest request, HttpServletResponse response) {
         // 요청에서 AccessToken 추출
-        String accessToken = resolveToken(request);
+        String accessToken = jwtUtil.resolveToken(request);
         if (accessToken == null) {
             throw new UserException(ErrorStatus.TOKEN_NOT_FOUND);
         }
@@ -158,14 +158,6 @@ public class UserServiceImpl implements UserService {
         if (userRepository.existsByEmail(email)) {
             throw new UserException(ErrorStatus.USER_ALREADY_EXISTS);
         }
-    }
-
-    /**
-     * 요청에서 JWT 토큰 추출
-     */
-    private String resolveToken(HttpServletRequest request) {
-        String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
-        return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
     }
 
     // 비밀번호 변경
@@ -301,7 +293,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public void withdraw(HttpServletRequest request) {
-        String accessToken = resolveToken(request);
+        String accessToken = jwtUtil.resolveToken(request);
         if (accessToken == null) {
             throw new UserException(ErrorStatus.TOKEN_NOT_FOUND);
         }

--- a/src/main/java/dgu/sw/global/security/JwtUtil.java
+++ b/src/main/java/dgu/sw/global/security/JwtUtil.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
@@ -74,7 +75,7 @@ public class JwtUtil {
 
     // HTTP 요청에서 Authorization 헤더에서 JWT 토큰 추출
     public String resolveToken(HttpServletRequest request) {
-        String bearer = request.getHeader("Authorization");
+        String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
         return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
     }
 


### PR DESCRIPTION
## Related Issue 🍀
- #156 

<br>

## Key Changes 🔑
- MockTest에서 createdDate(LocalDate) 필드 제거
- BaseEntity의 createdAt(LocalDateTime)을 기준으로 최근 모의고사 조회
- findTopByUser_UserIdOrderByCreatedAtDesc 메서드 반환 타입 Optional로 받고 null-safe 처리

<br>

## To Reviewers 🙏🏻
- 