### PR TITLE
[Feature] #183 - Role 기반 인증을 위한 JwtAuthenticationToken 커스텀 및 관련 인증 로직 구현

### DIFF
--- a/src/main/java/dgu/sw/domain/admin/controller/AdminController.java
+++ b/src/main/java/dgu/sw/domain/admin/controller/AdminController.java
@@ -3,17 +3,18 @@ package dgu.sw.domain.admin.controller;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminMannerRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminQuizRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminVocaRequest;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminMannerResponse;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminQuizResponse;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminUserResponse;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminVocaResponse;
 import dgu.sw.domain.admin.service.AdminService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
-import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
-@Controller
+import java.util.List;
+
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/admin")
 @Tag(name = "Admin 컨트롤러", description = "관리자 관련 화면 렌더링")
@@ -21,87 +22,63 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    @GetMapping("")
-    public String adminHome() {
-        return "admin/home"; // templates/admin/home.html
-    }
-
+    // 사용자 전체 조회
     @GetMapping("/users")
-    public String showUserList(Model model) {
-        model.addAttribute("users", adminService.getAllUsers());
-        return "admin/users"; // resources/templates/admin/users.html
+    public List<AdminUserResponse> getAllUsers() {
+        return adminService.getAllUsers();
     }
 
+    // 매너 전체 조회
     @GetMapping("/manners")
-    public String showManners(Model model) {
-        model.addAttribute("manners", adminService.getAllManners());
-        return "admin/manners_list";
+    public List<AdminMannerResponse> getAllManners() {
+        return adminService.getAllManners();
     }
 
-    @PostMapping("/manners/{mannerId}/delete")
-    public String deleteManner(@PathVariable Long mannerId) {
-        adminService.deleteManner(mannerId);
-        return "redirect:/admin/manners";
-    }
-
-    @GetMapping("/manners/new")
-    public String showMannerForm(Model model) {
-        model.addAttribute("manner", new AdminMannerRequest());
-        return "admin/manners_form"; // 등록 폼
-    }
-
+    // 매너 등록
     @PostMapping("/manners")
-    public String saveManner(AdminMannerRequest request) {
+    public void saveManner(@RequestBody AdminMannerRequest request) {
         adminService.saveManner(request);
-        return "redirect:/admin/manners";
     }
 
+    // 매너 삭제
+    @DeleteMapping("/manners/{mannerId}")
+    public void deleteManner(@PathVariable Long mannerId) {
+        adminService.deleteManner(mannerId);
+    }
+
+    // 퀴즈 전체 조회
     @GetMapping("/quizzes")
-    public String showQuizzes(Model model) {
-        model.addAttribute("quizzes", adminService.getAllQuizzes());
-        return "admin/quizzes_list";
+    public List<AdminQuizResponse> getAllQuizzes() {
+        return adminService.getAllQuizzes();
     }
 
-    @GetMapping("/quizzes/new")
-    public String showQuizForm(Model model) {
-        model.addAttribute("quiz", new AdminQuizRequest());
-        return "admin/quizzes_form";
-    }
-
+    // 퀴즈 등록
     @PostMapping("/quizzes")
-    public String saveQuiz(AdminQuizRequest request) {
+    public void saveQuiz(@RequestBody AdminQuizRequest request) {
         adminService.saveQuiz(request);
-        return "redirect:/admin/quizzes";
     }
 
-    @PostMapping("/quizzes/{quizId}/delete")
-    public String deleteQuiz(@PathVariable Long quizId) {
+    // 퀴즈 삭제
+    @DeleteMapping("/quizzes/{quizId}")
+    public void deleteQuiz(@PathVariable Long quizId) {
         adminService.deleteQuiz(quizId);
-        return "redirect:/admin/quizzes";
     }
 
-
+    // 단어 전체 조회
     @GetMapping("/vocas")
-    public String showVocaList(Model model) {
-        model.addAttribute("vocas", adminService.getAllVocas());
-        return "admin/vocas_list";
+    public List<AdminVocaResponse> getAllVocas() {
+        return adminService.getAllVocas();
     }
 
-    @GetMapping("/vocas/new")
-    public String showVocaForm(Model model) {
-        model.addAttribute("voca", new AdminVocaRequest());
-        return "admin/vocas_form";
-    }
-
+    // 단어 등록
     @PostMapping("/vocas")
-    public String saveVoca(AdminVocaRequest request) {
+    public void saveVoca(@RequestBody AdminVocaRequest request) {
         adminService.saveVoca(request);
-        return "redirect:/admin/vocas";
     }
 
-    @PostMapping("/vocas/{vocaId}/delete")
-    public String deleteVoca(@PathVariable Long vocaId) {
+    // 단어 삭제
+    @DeleteMapping("/vocas/{vocaId}")
+    public void deleteVoca(@PathVariable Long vocaId) {
         adminService.deleteVoca(vocaId);
-        return "redirect:/admin/vocas";
     }
 }

--- a/src/main/java/dgu/sw/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/admin/service/AdminServiceImpl.java
@@ -1,21 +1,32 @@
 package dgu.sw.domain.admin.service;
 
-import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminVocaRequest;
-import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminVocaResponse;
+import dgu.sw.domain.user.converter.UserConverter;
+import dgu.sw.domain.user.dto.UserDTO.UserRequest.SignInRequest;
+import dgu.sw.domain.user.dto.UserDTO.UserResponse.SignInResponse;
 import dgu.sw.domain.admin.converter.AdminConverter;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminMannerRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminQuizRequest;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminVocaRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminMannerResponse;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminQuizResponse;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminUserResponse;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminVocaResponse;
 import dgu.sw.domain.manner.entity.Manner;
 import dgu.sw.domain.manner.repository.MannerRepository;
 import dgu.sw.domain.quiz.entity.Quiz;
 import dgu.sw.domain.quiz.repository.QuizRepository;
+import dgu.sw.domain.user.entity.Role;
+import dgu.sw.domain.user.entity.User;
 import dgu.sw.domain.user.repository.UserRepository;
 import dgu.sw.domain.voca.repository.VocaRepository;
+import dgu.sw.global.exception.UserException;
+import dgu.sw.global.security.JwtTokenProvider;
+import dgu.sw.global.security.JwtUtil;
+import dgu.sw.global.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -28,6 +39,9 @@ public class AdminServiceImpl implements AdminService {
     private final MannerRepository mannerRepository;
     private final QuizRepository quizRepository;
     private final VocaRepository vocaRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtUtil jwtUtil;
 
     @Override
     public List<AdminUserResponse> getAllUsers() {

--- a/src/main/java/dgu/sw/domain/auth/converter/AuthConverter.java
+++ b/src/main/java/dgu/sw/domain/auth/converter/AuthConverter.java
@@ -2,8 +2,8 @@ package dgu.sw.domain.auth.converter;
 
 import dgu.sw.domain.auth.dto.AuthDTO.AuthResponse.AuthUserResponse;
 import dgu.sw.domain.auth.dto.AuthUserProfile;
+import dgu.sw.domain.user.entity.Role;
 import dgu.sw.domain.user.entity.User;
-import dgu.sw.global.security.OAuthProvider;
 
 public class AuthConverter {
 
@@ -13,6 +13,7 @@ public class AuthConverter {
                 .nickname(profile.getNickname())
                 .profileImage(profile.getProfileImage())
                 .provider(profile.getProvider())
+                .role(Role.USER)
                 .build();
     }
 

--- a/src/main/java/dgu/sw/domain/user/converter/UserConverter.java
+++ b/src/main/java/dgu/sw/domain/user/converter/UserConverter.java
@@ -4,6 +4,7 @@ import dgu.sw.domain.user.dto.UserDTO.UserResponse.MyPageResponse;
 import dgu.sw.domain.user.dto.UserDTO.UserResponse.SignUpResponse;
 import dgu.sw.domain.user.dto.UserDTO.UserRequest.SignUpRequest;
 import dgu.sw.domain.user.dto.UserDTO.UserResponse.SignInResponse;
+import dgu.sw.domain.user.entity.Role;
 import dgu.sw.domain.user.entity.User;
 import dgu.sw.global.security.OAuthProvider;
 
@@ -29,6 +30,7 @@ public class UserConverter {
                 .password(password)
                 .joinDate(signUpRequest.getJoinDate())
                 .provider(OAuthProvider.GENERAL)
+                .role(Role.USER)
                 .build();
     }
 

--- a/src/main/java/dgu/sw/domain/user/entity/Role.java
+++ b/src/main/java/dgu/sw/domain/user/entity/Role.java
@@ -1,0 +1,6 @@
+package dgu.sw.domain.user.entity;
+
+public enum Role {
+    USER,  // 기본 사용자 역할
+    ADMIN  // 관리자 역할
+}

--- a/src/main/java/dgu/sw/domain/user/entity/User.java
+++ b/src/main/java/dgu/sw/domain/user/entity/User.java
@@ -31,6 +31,8 @@ public class User extends BaseEntity {
     private String profileImage;
     @Enumerated(EnumType.STRING)
     private OAuthProvider provider;
+    @Enumerated(EnumType.STRING)
+    private Role role = Role.USER;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<UserQuiz> userQuizzes;

--- a/src/main/java/dgu/sw/global/config/SecurityConfig.java
+++ b/src/main/java/dgu/sw/global/config/SecurityConfig.java
@@ -70,11 +70,11 @@ public class SecurityConfig {
                                 new AntPathRequestMatcher("/swagger-ui/**"),
                                 new AntPathRequestMatcher("/v3/api-docs/**"),
                                 new AntPathRequestMatcher("/api-docs/**"),
-                                new AntPathRequestMatcher("/error"),
+                                new AntPathRequestMatcher("/admin/login"),
                                 new AntPathRequestMatcher("/favicon.ico"),
-                                new AntPathRequestMatcher("/health"),
-                                new AntPathRequestMatcher("/admin/**")
+                                new AntPathRequestMatcher("/health")
                         ).permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();

--- a/src/main/java/dgu/sw/global/security/CustomUserDetails.java
+++ b/src/main/java/dgu/sw/global/security/CustomUserDetails.java
@@ -3,6 +3,7 @@ package dgu.sw.global.security;
 import dgu.sw.domain.user.entity.User;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Collection;
@@ -19,11 +20,13 @@ public class CustomUserDetails implements UserDetails {
     private final Long id;
     private final String email;
     private final String password;
+    private final String role;
 
     public CustomUserDetails(User user) {
         this.id = user.getUserId();
         this.email = user.getEmail();
         this.password = user.getPassword();
+        this.role = user.getRole().toString();
     }
 
     /**
@@ -32,8 +35,11 @@ public class CustomUserDetails implements UserDetails {
      */
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.emptyList(); // 역할이 추가되면 여기서 관리 가능
+        return Collections.singletonList(
+                new SimpleGrantedAuthority("ROLE_" + role) // prefix 붙이기!
+        );
     }
+
 
     /**
      * Spring Security에서 사용자명을 반환하는 메서드

--- a/src/main/java/dgu/sw/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/dgu/sw/global/security/JwtAuthenticationFilter.java
@@ -10,7 +10,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
@@ -45,8 +44,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 if (jwtUtil.validateToken(token)) {
                     // 인증 토큰 생성하고 AuthenticationManager를 통해 인증 수행
+                    Long userId = jwtUtil.extractUserId(token);
+                    String role = jwtUtil.extractRole(token);
                     Authentication authentication = authenticationManager.authenticate(
-                            new UsernamePasswordAuthenticationToken(token, null)
+                            new JwtAuthenticationToken(userId, role)
                     );
                     // 인증이 성공하면 SecurityContext에 저장하여 이후의 요청에서 인증 정보 활용 가능하게 함
                     SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/dgu/sw/global/security/JwtAuthenticationToken.java
+++ b/src/main/java/dgu/sw/global/security/JwtAuthenticationToken.java
@@ -1,0 +1,37 @@
+package dgu.sw.global.security;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final Object principal;   // 예: userId
+    private final Object credentials; // 예: role
+
+    public JwtAuthenticationToken(Object principal, Object credentials) {
+        super(null); // 권한은 인증 전에는 null
+        this.principal = principal;
+        this.credentials = credentials;
+        setAuthenticated(false);
+    }
+
+    public JwtAuthenticationToken(Object principal, Object credentials,
+                                  Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+}

--- a/src/main/java/dgu/sw/global/security/JwtTokenProvider.java
+++ b/src/main/java/dgu/sw/global/security/JwtTokenProvider.java
@@ -43,21 +43,22 @@ public class JwtTokenProvider {
 
     // AccessToken 생성 (userId를 Subject로 설정)
     public String generateAccessToken(User user) {
-        return createToken(user.getUserId(), user.getEmail(), jwtExpirationInMs);
+        return createToken(user.getUserId(), user.getEmail(), user.getRole().toString(), jwtExpirationInMs);
     }
 
     // RefreshToken 생성 및 Redis 저장
     public String generateRefreshToken(User user) {
-        String token = createToken(user.getUserId(), user.getEmail(), jwtRefreshExpirationInMs);
+        String token = createToken(user.getUserId(), user.getEmail(), user.getRole().toString(), jwtRefreshExpirationInMs);
         redisTemplate.opsForValue().set(String.valueOf(user.getUserId()), token, jwtRefreshExpirationInMs, TimeUnit.MILLISECONDS);
         return token;
     }
 
     // JWT 생성 로직 (userId를 Subject로 설정)
-    private String createToken(Long userId, String email, long expirationMs) {
+    private String createToken(Long userId, String email, String role, long expirationMs) {
         return Jwts.builder()
-                .setSubject(String.valueOf(userId)) // userId를 Subject로 저장
-                .claim("email", email) // email을 claims로 저장
+                .setSubject(String.valueOf(userId))
+                .claim("email", email)
+                .claim("role", role)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + expirationMs))
                 .signWith(secretKey, SignatureAlgorithm.HS512)

--- a/src/main/java/dgu/sw/global/security/JwtUtil.java
+++ b/src/main/java/dgu/sw/global/security/JwtUtil.java
@@ -62,6 +62,20 @@ public class JwtUtil {
         }
     }
 
+    public String extractRole(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .get("role", String.class); // "role" 클레임에서 값을 추출
+        } catch (Exception e) {
+            LOGGER.warning("Failed to extract role from token: " + e.getMessage());
+            return null;
+        }
+    }
+
     // JWT 유효성 검사
     public boolean validateToken(String token) {
         try {

--- a/src/main/java/dgu/sw/global/status/ErrorStatus.java
+++ b/src/main/java/dgu/sw/global/status/ErrorStatus.java
@@ -38,6 +38,7 @@ public enum ErrorStatus implements BaseErrorCode {
     JOIN_DATE_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "USER4012", "이미 입사일이 등록된 사용자입니다."),
     SOCIAL_USER_CANNOT_CHANGE_PASSWORD(HttpStatus.FORBIDDEN, "USER4013", "소셜 로그인 사용자는 비밀번호를 변경할 수 없습니다."),
     LOGGED_OUT_TOKEN(HttpStatus.UNAUTHORIZED, "USER4013", "이미 로그아웃된 토큰입니다."),
+    FORBIDDEN_ACCESS(HttpStatus.UNAUTHORIZED, "USER4014", "관리자 권한이 없습니다."),
 
     // 업무 용어 관련 에러
     VOCA_NOT_FOUND(HttpStatus.NOT_FOUND, "VOCA4041", "해당 업무 용어를 찾을 수 없습니다."),


### PR DESCRIPTION
## Related Issue 🍀
- #183 

<br>

## Key Changes 🔑
- 'JwtAuthenticationToken' 클래스 정의
  - 'principal'에 userId, 'credentials'에 role 저장
- 'JwtAuthenticationFilter' 수정
  - 'JwtUtil'로부터 userId 및 role 추출 후 JwtAuthenticationToken 생성
- 'JwtAuthenticationProvider' 구현
  - 토큰에서 추출한 정보로 사용자 인증 수행
  - 'supports()'에서 'JwtAuthenticationToken' 처리
- 'CustomUserDetails'에서 'ROLE_' prefix가 붙은 권한 반환
- JWT 토큰 생성 시 'role' 클레임 포함
- '/admin/**' 경로에 hasRole("ADMIN")' 권한 적용

<br>

## To Reviewers 🙏🏻
- 