### PR TITLE
[Fix] #190 - 프론트 도메인 대응을 위한 CORS 설정 allowedOriginPatterns로 변경

### DIFF
--- a/src/main/java/dgu/sw/global/config/WebConfig.java
+++ b/src/main/java/dgu/sw/global/config/WebConfig.java
@@ -14,6 +14,7 @@ public class WebConfig {
             @Override
             public void addCorsMappings(CorsRegistry registry) {
                 registry.addMapping("/**")
+                        .allowedOriginPatterns("*")
                         .allowedOrigins("http://localhost:8080", "http://localhost:3000", "http://localhost:5173")
                         .allowedMethods("GET", "POST", "PATCH", "PUT", "DELETE")
                         .allowedHeaders("*")


### PR DESCRIPTION
## Related Issue 🍀
- #190 

<br>

## Key Changes 🔑
- 로컬 환경 (http://localhost:3000/, http://localhost:5173/) 뿐 아니라
- 배포된 프론트엔드 도메인 등 다양한 출처에서의 요청 정상 수락 가능
- Kakao 로그인 리디렉션 이후 백엔드 요청 차단 문제 해결

<br>

## To Reviewers 🙏🏻
- 