### PR TITLE
[Feature] #194 - 카카오 로그인 → 일반 로그인 및 JWT 토큰 인증 기반 API 변경

### DIFF
--- a/src/main/java/dgu/sw/domain/admin/controller/AdminController.java
+++ b/src/main/java/dgu/sw/domain/admin/controller/AdminController.java
@@ -1,5 +1,7 @@
 package dgu.sw.domain.admin.controller;
 
+import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminLoginResponse;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminLoginRequest;;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminMannerRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminQuizRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminVocaRequest;
@@ -10,6 +12,7 @@ import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminVocaResponse;
 import dgu.sw.domain.admin.service.AdminService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,63 +25,68 @@ public class AdminController {
 
     private final AdminService adminService;
 
+    // 관리자 로그인
+    @PostMapping("/login")
+    public AdminLoginResponse login(@RequestBody AdminLoginRequest request) {
+        return adminService.login(request);
+    }
     // 사용자 전체 조회
     @GetMapping("/users")
-    public List<AdminUserResponse> getAllUsers() {
-        return adminService.getAllUsers();
+    public List<AdminUserResponse> getAllUsers(Authentication authentication) {
+        return adminService.getAllUsers(authentication.getName());
     }
 
     // 매너 전체 조회
     @GetMapping("/manners")
-    public List<AdminMannerResponse> getAllManners() {
-        return adminService.getAllManners();
+    public List<AdminMannerResponse> getAllManners(Authentication authentication) {
+        return adminService.getAllManners(authentication.getName());
     }
 
     // 매너 등록
     @PostMapping("/manners")
-    public void saveManner(@RequestBody AdminMannerRequest request) {
-        adminService.saveManner(request);
+    public void saveManner(@RequestBody AdminMannerRequest request, Authentication authentication) {
+        adminService.saveManner(request, authentication.getName());
     }
 
     // 매너 삭제
     @DeleteMapping("/manners/{mannerId}")
-    public void deleteManner(@PathVariable Long mannerId) {
-        adminService.deleteManner(mannerId);
+    public void deleteManner(@PathVariable Long mannerId, Authentication authentication) {
+        adminService.deleteManner(mannerId, authentication.getName());
     }
 
     // 퀴즈 전체 조회
     @GetMapping("/quizzes")
-    public List<AdminQuizResponse> getAllQuizzes() {
-        return adminService.getAllQuizzes();
+    public List<AdminQuizResponse> getAllQuizzes(Authentication authentication) {
+        return adminService.getAllQuizzes(authentication.getName());
     }
 
     // 퀴즈 등록
     @PostMapping("/quizzes")
-    public void saveQuiz(@RequestBody AdminQuizRequest request) {
-        adminService.saveQuiz(request);
+    public void saveQuiz(@RequestBody AdminQuizRequest request, Authentication authentication) {
+        adminService.saveQuiz(request, authentication.getName());
     }
 
     // 퀴즈 삭제
     @DeleteMapping("/quizzes/{quizId}")
-    public void deleteQuiz(@PathVariable Long quizId) {
-        adminService.deleteQuiz(quizId);
+    public void deleteQuiz(@PathVariable Long quizId, Authentication authentication) {
+        adminService.deleteQuiz(quizId, authentication.getName());
     }
 
     // 단어 전체 조회
     @GetMapping("/vocas")
-    public List<AdminVocaResponse> getAllVocas() {
-        return adminService.getAllVocas();
+    public List<AdminVocaResponse> getAllVocas(Authentication authentication) {
+        return adminService.getAllVocas(authentication.getName());
     }
 
     // 단어 등록
     @PostMapping("/vocas")
-    public void saveVoca(@RequestBody AdminVocaRequest request) {
-        adminService.saveVoca(request);
+    public void saveVoca(@RequestBody AdminVocaRequest request, Authentication authentication) {
+        adminService.saveVoca(request, authentication.getName());
     }
 
     // 단어 삭제
     @DeleteMapping("/vocas/{vocaId}")
-    public void deleteVoca(@PathVariable Long vocaId) {
-        adminService.deleteVoca(vocaId);
+    public void deleteVoca(@PathVariable Long vocaId, Authentication authentication) {
+        adminService.deleteVoca(vocaId, authentication.getName());
     }
 }

--- a/src/main/java/dgu/sw/domain/admin/converter/AdminConverter.java
+++ b/src/main/java/dgu/sw/domain/admin/converter/AdminConverter.java
@@ -1,5 +1,6 @@
 package dgu.sw.domain.admin.converter;
 
+import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminLoginResponse;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminVocaRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminVocaResponse;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminMannerRequest;
@@ -13,6 +14,17 @@ import dgu.sw.domain.user.entity.User;
 import dgu.sw.domain.voca.entity.Voca;
 
 public class AdminConverter {
+
+    public static AdminLoginResponse toAdminLoginResponse(String accessToken, String refreshToken, User user) {
+        return AdminLoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+
     public static AdminUserResponse toAdminUserResponse(User user) {
         return AdminUserResponse.builder()
                 .userId(user.getUserId())

--- a/src/main/java/dgu/sw/domain/admin/dto/AdminDTO.java
+++ b/src/main/java/dgu/sw/domain/admin/dto/AdminDTO.java
@@ -8,6 +8,16 @@ import java.time.LocalDateTime;
 public class AdminDTO {
 
     public static class AdminRequest {
+
+        @Getter
+        @Setter
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class AdminLoginRequest {
+            private String email;
+            private String password;
+        }
+
         @Getter
         @Setter
         @NoArgsConstructor
@@ -44,6 +54,18 @@ public class AdminDTO {
     }
 
     public static class AdminResponse {
+
+        @Getter
+        @Builder
+        @AllArgsConstructor
+        public static class AdminLoginResponse {
+            private String accessToken;
+            private String refreshToken;
+            private Long userId;
+            private String email;
+            private String nickname;
+        }
+
         @Getter
         @Builder
         public static class AdminUserResponse {

--- a/src/main/java/dgu/sw/domain/admin/service/AdminService.java
+++ b/src/main/java/dgu/sw/domain/admin/service/AdminService.java
@@ -1,6 +1,8 @@
 package dgu.sw.domain.admin.service;
 
-import dgu.sw.domain.admin.dto.AdminDTO;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminLoginResponse;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminLoginRequest;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminMannerRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminQuizRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminVocaRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminMannerResponse;
@@ -11,14 +13,15 @@ import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminVocaResponse;
 import java.util.List;
 
 public interface AdminService {
-    List<AdminUserResponse> getAllUsers();
-    List<AdminMannerResponse> getAllManners();
-    void deleteManner(Long mannerId);
-    void saveManner(AdminDTO.AdminRequest.AdminMannerRequest request);
-    List<AdminQuizResponse> getAllQuizzes();
-    void saveQuiz(AdminQuizRequest request);
-    void deleteQuiz(Long quizId);
-    List<AdminVocaResponse> getAllVocas();
-    void saveVoca(AdminVocaRequest request);
-    void deleteVoca(Long vocaId);
+    AdminLoginResponse login(AdminLoginRequest request);
+    List<AdminUserResponse> getAllUsers(String userId);
+    List<AdminMannerResponse> getAllManners(String userId);
+    void deleteManner(Long mannerId, String userId);
+    void saveManner(AdminMannerRequest request, String userId);
+    List<AdminQuizResponse> getAllQuizzes(String userId);
+    void saveQuiz(AdminQuizRequest request, String userId);
+    void deleteQuiz(Long quizId, String userId);
+    List<AdminVocaResponse> getAllVocas(String userId);
+    void saveVoca(AdminVocaRequest request, String userId);
+    void deleteVoca(Long vocaId, String userId);
 }

--- a/src/main/java/dgu/sw/domain/admin/service/AdminServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/admin/service/AdminServiceImpl.java
@@ -1,8 +1,7 @@
 package dgu.sw.domain.admin.service;
 
-import dgu.sw.domain.user.converter.UserConverter;
-import dgu.sw.domain.user.dto.UserDTO.UserRequest.SignInRequest;
-import dgu.sw.domain.user.dto.UserDTO.UserResponse.SignInResponse;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminLoginResponse;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminLoginRequest;
 import dgu.sw.domain.admin.converter.AdminConverter;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminMannerRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminQuizRequest;
@@ -19,11 +18,11 @@ import dgu.sw.domain.user.entity.Role;
 import dgu.sw.domain.user.entity.User;
 import dgu.sw.domain.user.repository.UserRepository;
 import dgu.sw.domain.voca.repository.VocaRepository;
+import dgu.sw.global.config.redis.RedisUtil;
 import dgu.sw.global.exception.UserException;
 import dgu.sw.global.security.JwtTokenProvider;
 import dgu.sw.global.security.JwtUtil;
 import dgu.sw.global.status.ErrorStatus;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -42,16 +41,54 @@ public class AdminServiceImpl implements AdminService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtUtil jwtUtil;
+    private final RedisUtil redisUtil;
 
     @Override
-    public List<AdminUserResponse> getAllUsers() {
+    public AdminLoginResponse login(AdminLoginRequest request) {
+        User admin = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+
+        // 관리자 권한 확인
+        if (!admin.getRole().equals(Role.ADMIN)) {
+            throw new UserException(ErrorStatus.FORBIDDEN_ACCESS);
+        }
+
+        // 비밀번호 일치 확인 (bcrypt 비교)
+        if (!passwordEncoder.matches(request.getPassword(), admin.getPassword())) {
+            throw new UserException(ErrorStatus.INVALID_CREDENTIALS);
+        }
+
+        // 토큰 생성
+        String accessToken = jwtTokenProvider.generateAccessToken(admin);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(admin);
+
+        // Redis에 RefreshToken 저장
+        redisUtil.saveRefreshToken(admin.getUserId().toString(), refreshToken);
+
+        return AdminConverter.toAdminLoginResponse(accessToken, refreshToken, admin);
+    }
+
+    private void checkAdminRole(String userId) {
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+
+        // 사용자 권한 확인
+        if (!user.getRole().equals(Role.ADMIN)) {
+            throw new UserException(ErrorStatus.FORBIDDEN_ACCESS);
+        }
+    }
+
+    @Override
+    public List<AdminUserResponse> getAllUsers(String userId) {
+        checkAdminRole(userId);  // 권한 확인
         return userRepository.findAll().stream()
                 .map(AdminConverter::toAdminUserResponse)
                 .collect(Collectors.toList());
     }
 
     @Override
-    public List<AdminMannerResponse> getAllManners() {
+    public List<AdminMannerResponse> getAllManners(String userId) {
+        checkAdminRole(userId);  // 권한 확인
         return mannerRepository.findAll().stream()
                 .map(AdminConverter::toAdminMannerResponse)
                 .collect(Collectors.toList());
@@ -59,19 +96,22 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     @Transactional
-    public void deleteManner(Long mannerId) {
+    public void deleteManner(Long mannerId, String userId) {
+        checkAdminRole(userId);  // 권한 확인
         mannerRepository.deleteById(mannerId);
     }
 
     @Override
     @Transactional
-    public void saveManner(AdminMannerRequest request) {
+    public void saveManner(AdminMannerRequest request, String userId) {
+        checkAdminRole(userId);  // 권한 확인
         Manner manner = AdminConverter.toManner(request);
         mannerRepository.save(manner);
     }
 
     @Override
-    public List<AdminQuizResponse> getAllQuizzes() {
+    public List<AdminQuizResponse> getAllQuizzes(String userId) {
+        checkAdminRole(userId);  // 권한 확인
         return quizRepository.findAll().stream()
                 .map(AdminConverter::toAdminQuizResponse)
                 .collect(Collectors.toList());
@@ -79,19 +119,22 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     @Transactional
-    public void saveQuiz(AdminQuizRequest request) {
+    public void saveQuiz(AdminQuizRequest request, String userId) {
+        checkAdminRole(userId);  // 권한 확인
         Quiz quiz = AdminConverter.toQuiz(request);
         quizRepository.save(quiz);
     }
 
     @Override
     @Transactional
-    public void deleteQuiz(Long quizId) {
+    public void deleteQuiz(Long quizId, String userId) {
+        checkAdminRole(userId);  // 권한 확인
         quizRepository.deleteById(quizId);
     }
 
     @Override
-    public List<AdminVocaResponse> getAllVocas() {
+    public List<AdminVocaResponse> getAllVocas(String userId) {
+        checkAdminRole(userId);  // 권한 확인
         return vocaRepository.findAll().stream()
                 .map(AdminConverter::toAdminVocaResponse)
                 .collect(Collectors.toList());
@@ -99,13 +142,15 @@ public class AdminServiceImpl implements AdminService {
 
     @Override
     @Transactional
-    public void saveVoca(AdminVocaRequest request) {
+    public void saveVoca(AdminVocaRequest request, String userId) {
+        checkAdminRole(userId);  // 권한 확인
         vocaRepository.save(AdminConverter.toVoca(request));
     }
 
     @Override
     @Transactional
-    public void deleteVoca(Long vocaId) {
+    public void deleteVoca(Long vocaId, String userId) {
+        checkAdminRole(userId);  // 권한 확인
         vocaRepository.deleteById(vocaId);
     }
 }


### PR DESCRIPTION
## Related Issue 🍀
- #194 

<br>

## Key Changes 🔑
- 카카오 로그인을 일반 로그인 방식으로 변경
- JWT 기반 API 요청에 'Authorization' 헤더 포함하도록 수정

<br>

## To Reviewers 🙏🏻
<img width="1284" alt="스크린샷 2025-07-10 오후 5 48 46" src="https://github.com/user-attachments/assets/1898e434-9324-44c0-8cad-19801a6418f9" />
