### PR TITLE
[Fix] #196 - refreshToken 전달 방식 변경

### DIFF
--- a/src/main/java/dgu/sw/domain/user/controller/UserController.java
+++ b/src/main/java/dgu/sw/domain/user/controller/UserController.java
@@ -42,8 +42,9 @@ public class UserController {
 
     @PostMapping("/refresh")
     @Operation(summary = "토큰 갱신 API", description = "Refresh Token을 이용하여 Access Token을 갱신합니다.")
-    public ApiResponse<SignInResponse> refresh(@RequestHeader("refreshToken") String refreshToken, HttpServletResponse response) {
-        return ApiResponse.onSuccess(userService.refreshAccessToken(refreshToken, response));
+    public ApiResponse<SignInResponse> refresh(@RequestHeader("Authorization") String authorizationHeader) {
+        String refreshToken = authorizationHeader.replace("Bearer ", "");
+        return ApiResponse.onSuccess(userService.refreshAccessToken(refreshToken));
     }
 
     @PostMapping("/check-email")

--- a/src/main/java/dgu/sw/domain/user/service/UserService.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserService.java
@@ -14,7 +14,7 @@ public interface UserService {
 
     void signOut(HttpServletRequest request, HttpServletResponse response);
 
-    SignInResponse refreshAccessToken(String refreshToken, HttpServletResponse response);
+    SignInResponse refreshAccessToken(String refreshToken);
 
     void checkEmailDuplicate(String email);
 

--- a/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
@@ -1,33 +1,30 @@
 package dgu.sw.domain.user.service;
 
 import dgu.sw.domain.user.converter.UserConverter;
-import dgu.sw.domain.user.dto.UserDTO.UserResponse.UpdateJoinDateResponse;
+import dgu.sw.domain.user.dto.UserDTO.UserRequest.PasswordResetRequest;
+import dgu.sw.domain.user.dto.UserDTO.UserRequest.SignInRequest;
+import dgu.sw.domain.user.dto.UserDTO.UserRequest.SignUpRequest;
 import dgu.sw.domain.user.dto.UserDTO.UserResponse.MyPageResponse;
 import dgu.sw.domain.user.dto.UserDTO.UserResponse.SignInResponse;
+import dgu.sw.domain.user.dto.UserDTO.UserResponse.SignUpResponse;
+import dgu.sw.domain.user.dto.UserDTO.UserResponse.UpdateJoinDateResponse;
 import dgu.sw.domain.user.entity.User;
 import dgu.sw.domain.user.repository.UserRepository;
+import dgu.sw.global.config.redis.RedisUtil;
+import dgu.sw.global.config.util.EmailService;
+import dgu.sw.global.exception.UserException;
 import dgu.sw.global.security.JwtTokenProvider;
 import dgu.sw.global.security.JwtUtil;
-import dgu.sw.global.config.redis.RedisUtil;
-import dgu.sw.global.exception.UserException;
 import dgu.sw.global.security.OAuthProvider;
 import dgu.sw.global.security.OAuthUtil;
 import dgu.sw.global.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import dgu.sw.domain.user.dto.UserDTO.UserResponse.SignUpResponse;
-import dgu.sw.domain.user.dto.UserDTO.UserRequest.SignUpRequest;
-import dgu.sw.domain.user.dto.UserDTO.UserRequest.SignInRequest;
-import dgu.sw.domain.user.dto.UserDTO.UserRequest.PasswordResetRequest;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-
-import dgu.sw.global.config.util.EmailService;
 
 import java.time.LocalDate;
 
@@ -122,7 +119,7 @@ public class UserServiceImpl implements UserService {
      * AccessToken 갱신
      */
     @Override
-    public SignInResponse refreshAccessToken(String refreshToken, HttpServletResponse response) {
+    public SignInResponse refreshAccessToken(String refreshToken) {
         Long extractedUserId = jwtUtil.extractUserId(refreshToken);
         if (extractedUserId == null) {
             throw new UserException(ErrorStatus.INVALID_REFRESH_TOKEN);


### PR DESCRIPTION
## Related Issue 🍀
- #196 

<br>

## Key Changes 🔑
- Authorization 헤더에서 Bearer refreshToken 추출
- redis에 저장된 refreshToken과 비교 후 AccessToken 재발급

<br>

## To Reviewers 🙏🏻
- 