### PR TITLE
[Refactor] #203 - Provider에 GENERAL 추가됨에 따라 비밀번호 변경 시 이메일 인증 코드 수정

### DIFF
--- a/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
@@ -164,7 +164,7 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
 
-        if (user.getProvider() != null) {
+        if (user.getProvider() != OAuthProvider.GENERAL) {
             throw new UserException(ErrorStatus.SOCIAL_USER_CANNOT_CHANGE_PASSWORD);
         }
     }
@@ -176,7 +176,7 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
 
-        if (user.getProvider() != null) {
+        if (user.getProvider() != OAuthProvider.GENERAL) {
             throw new UserException(ErrorStatus.SOCIAL_USER_CANNOT_CHANGE_PASSWORD);
         }
 
@@ -252,7 +252,7 @@ public class UserServiceImpl implements UserService {
         // 1. 사용자 존재 확인
         User user = userRepository.findByEmail(email).orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
         // 소셜 로그인 사용자는 비밀번호 변경 제한
-        if (user.getProvider() != null) {
+        if (user.getProvider() != OAuthProvider.GENERAL) {
             throw new UserException(ErrorStatus.SOCIAL_USER_CANNOT_CHANGE_PASSWORD);
         }
 


### PR DESCRIPTION
## Related Issue 🍀
- close #203 

<br>

## Key Changes 🔑
- Provider에 GENERAL 추가됨에 따라 비밀번호 변경 시 이메일 인증 코드 수정
  - 'GENERAL = 일반 사용자'는 비밀번호 변경 기능 이용 가능하도록 수정
  - 이외 소셜 로그인 사용자(KAKAO, GOOGLE, NAVER, APPLE)는 비밀번호 변경 불가능