### PR TITLE
[Refactor] #188 - fcm json file 로드 방법 변경

### DIFF
--- a/src/main/java/dgu/sw/global/fcm/config/FirebaseInitializer.java
+++ b/src/main/java/dgu/sw/global/fcm/config/FirebaseInitializer.java
@@ -6,10 +6,7 @@ import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.Resource;
 import org.springframework.stereotype.Component;
-
 import java.io.IOException;
 
 @Slf4j
@@ -17,14 +14,11 @@ import java.io.IOException;
 @RequiredArgsConstructor
 public class FirebaseInitializer {
 
-    @Value("${fcm.file-path}")
-    private Resource firebaseConfig;
-
     @PostConstruct
     public void initialize() {
         try {
             FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.fromStream(firebaseConfig.getInputStream()))
+                    .setCredentials(GoogleCredentials.getApplicationDefault())
                     .build();
 
             if (FirebaseApp.getApps().isEmpty()) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,7 +53,6 @@ REDIS_PORT: ${REDIS_PORT}
 REDIS_TLS: ${REDIS_TLS}
 
 fcm:
-  file-path: ${FCM_JSON_PATH}
   url: https://fcm.googleapis.com/v1/projects/${FCM_PROJECT_ID}/messages:send
   google-api: https://www.googleapis.com/auth/cloud-platform
   project-id: ${FCM_PROJECT_ID}


### PR DESCRIPTION
## Related Issue 🍀
- #188 

<br>

## Key Changes 🔑
- fcm json file 로드 방법 변경
- 기존 방식
  ```java
  @Value("${fcm.file-path}")
  private Resource firebaseConfig;
  
  FirebaseOptions options = FirebaseOptions.builder()
      .setCredentials(GoogleCredentials.fromStream(firebaseConfig.getInputStream()))
      .build();
  
  ```
  - application.yml 또는 .properties에 fcm.file-path를 설정해두고 Spring이 자동으로 해당 경로의 파일을 읽도록 했었음

- 수정 방식
  ```
  FirebaseOptions options = FirebaseOptions.builder()
      .setCredentials(GoogleCredentials.getApplicationDefault())
      .build();
  ```
  - GOOGLE_APPLICATION_CREDENTIALS 환경변수를 통해 JSON 파일 경로를 지정함
  - 내부적으로 GoogleCredentials.getApplicationDefault() 가 환경변수의 경로를 읽어서 인증 정보를 생성함