### PR TITLE
[Refactor] #216 - Authentication.getName() 제거 및 @LoginUser Long userId 적용

### DIFF
--- a/src/main/java/dgu/sw/domain/admin/controller/AdminController.java
+++ b/src/main/java/dgu/sw/domain/admin/controller/AdminController.java
@@ -1,23 +1,20 @@
 package dgu.sw.domain.admin.controller;
 
-import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminFeedbackResponse;
-import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminLoginResponse;
-import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminLoginRequest;;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminLoginRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminMannerRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminQuizRequest;
 import dgu.sw.domain.admin.dto.AdminDTO.AdminRequest.AdminVocaRequest;
-import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminMannerResponse;
-import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminQuizResponse;
-import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminUserResponse;
-import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.AdminVocaResponse;
+import dgu.sw.domain.admin.dto.AdminDTO.AdminResponse.*;
 import dgu.sw.domain.admin.service.AdminService;
 import dgu.sw.global.ApiResponse;
+import dgu.sw.global.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+
+;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,94 +32,94 @@ public class AdminController {
 
     // 사용자 전체 조회
     @GetMapping("/users")
-    public ApiResponse<List<AdminUserResponse>> getAllUsers(Authentication authentication) {
-        return ApiResponse.onSuccess(adminService.getAllUsers(authentication.getName()));
+    public ApiResponse<List<AdminUserResponse>> getAllUsers(@LoginUser Long userId) {
+        return ApiResponse.onSuccess(adminService.getAllUsers(userId));
     }
 
     // 매너 전체 조회
     @GetMapping("/manners")
-    public ApiResponse<List<AdminMannerResponse>> getAllManners(Authentication authentication) {
-        return ApiResponse.onSuccess(adminService.getAllManners(authentication.getName()));
+    public ApiResponse<List<AdminMannerResponse>> getAllManners(@LoginUser Long userId) {
+        return ApiResponse.onSuccess(adminService.getAllManners(userId));
     }
 
     // 매너 등록
     @PostMapping("/manners")
-    public ApiResponse<String> saveManner(@RequestBody AdminMannerRequest request, Authentication authentication) {
-        adminService.saveManner(request, authentication.getName());
+    public ApiResponse<String> saveManner(@RequestBody AdminMannerRequest request, @LoginUser Long userId) {
+        adminService.saveManner(request, userId);
         return ApiResponse.onSuccess("매너가 등록되었습니다.");
     }
 
     // 매너 수정
     @PatchMapping("/manners/{mannerId}")
-    public ApiResponse<String> updateManner(@PathVariable Long mannerId, @RequestBody AdminMannerRequest request, Authentication authentication) {
-        adminService.updateManner(mannerId, request, authentication.getName());
+    public ApiResponse<String> updateManner(@PathVariable Long mannerId, @RequestBody AdminMannerRequest request, @LoginUser Long userId) {
+        adminService.updateManner(mannerId, request, userId);
         return ApiResponse.onSuccess("매너가 수정되었습니다.");
     }
 
     // 매너 삭제
     @DeleteMapping("/manners/{mannerId}")
-    public ApiResponse<String> deleteManner(@PathVariable Long mannerId, Authentication authentication) {
-        adminService.deleteManner(mannerId, authentication.getName());
+    public ApiResponse<String> deleteManner(@PathVariable Long mannerId, @LoginUser Long userId) {
+        adminService.deleteManner(mannerId, userId);
         return ApiResponse.onSuccess("매너가 삭제되었습니다.");
     }
 
     // 퀴즈 전체 조회
     @GetMapping("/quizzes")
-    public ApiResponse<List<AdminQuizResponse>> getAllQuizzes(Authentication authentication) {
-        return ApiResponse.onSuccess(adminService.getAllQuizzes(authentication.getName()));
+    public ApiResponse<List<AdminQuizResponse>> getAllQuizzes(@LoginUser Long userId) {
+        return ApiResponse.onSuccess(adminService.getAllQuizzes(userId));
     }
 
     // 퀴즈 등록
     @PostMapping("/quizzes")
-    public ApiResponse<String> saveQuiz(@RequestBody AdminQuizRequest request, Authentication authentication) {
-        adminService.saveQuiz(request, authentication.getName());
+    public ApiResponse<String> saveQuiz(@RequestBody AdminQuizRequest request, @LoginUser Long userId) {
+        adminService.saveQuiz(request, userId);
         return ApiResponse.onSuccess("퀴즈가 등록되었습니다.");
     }
 
     // 퀴즈 수정
     @PatchMapping("/quizzes/{quizId}")
-    public ApiResponse<String> updateQuiz(@PathVariable Long quizId, @RequestBody AdminQuizRequest request, Authentication authentication) {
-        adminService.updateQuiz(quizId, request, authentication.getName());
+    public ApiResponse<String> updateQuiz(@PathVariable Long quizId, @RequestBody AdminQuizRequest request, @LoginUser Long userId) {
+        adminService.updateQuiz(quizId, request, userId);
         return ApiResponse.onSuccess("퀴즈가 수정되었습니다.");
     }
 
     // 퀴즈 삭제
     @DeleteMapping("/quizzes/{quizId}")
-    public ApiResponse<String> deleteQuiz(@PathVariable Long quizId, Authentication authentication) {
-        adminService.deleteQuiz(quizId, authentication.getName());
+    public ApiResponse<String> deleteQuiz(@PathVariable Long quizId, @LoginUser Long userId) {
+        adminService.deleteQuiz(quizId, userId);
         return ApiResponse.onSuccess("퀴즈가 삭제되었습니다.");
     }
 
     // 단어 전체 조회
     @GetMapping("/vocas")
-    public ApiResponse<List<AdminVocaResponse>> getAllVocas(Authentication authentication) {
-        return ApiResponse.onSuccess(adminService.getAllVocas(authentication.getName()));
+    public ApiResponse<List<AdminVocaResponse>> getAllVocas(@LoginUser Long userId) {
+        return ApiResponse.onSuccess(adminService.getAllVocas(userId));
     }
 
     // 단어 등록
     @PostMapping("/vocas")
-    public ApiResponse<String> saveVoca(@RequestBody AdminVocaRequest request, Authentication authentication) {
-        adminService.saveVoca(request, authentication.getName());
+    public ApiResponse<String> saveVoca(@RequestBody AdminVocaRequest request, @LoginUser Long userId) {
+        adminService.saveVoca(request, userId);
         return ApiResponse.onSuccess("단어가 등록되었습니다.");
     }
 
     // 단어 수정
     @PatchMapping("/vocas/{vocaId}")
-    public ApiResponse<String> updateVoca(@PathVariable Long vocaId, @RequestBody AdminVocaRequest request, Authentication authentication) {
-        adminService.updateVoca(vocaId, request, authentication.getName());
+    public ApiResponse<String> updateVoca(@PathVariable Long vocaId, @RequestBody AdminVocaRequest request, @LoginUser Long userId) {
+        adminService.updateVoca(vocaId, request, userId);
         return ApiResponse.onSuccess("단어가 수정되었습니다.");
     }
 
     // 단어 삭제
     @DeleteMapping("/vocas/{vocaId}")
-    public ApiResponse<String> deleteVoca(@PathVariable Long vocaId, Authentication authentication) {
-        adminService.deleteVoca(vocaId, authentication.getName());
+    public ApiResponse<String> deleteVoca(@PathVariable Long vocaId, @LoginUser Long userId) {
+        adminService.deleteVoca(vocaId, userId);
         return ApiResponse.onSuccess("단어가 삭제되었습니다.");
     }
 
     // 앱 피드백 조회
     @GetMapping("/app")
-    public ApiResponse<List<AdminFeedbackResponse>> getFeedback(Authentication authentication) {
-        return ApiResponse.onSuccess(adminService.getAllFeedbacks(authentication.getName()));
+    public ApiResponse<List<AdminFeedbackResponse>> getFeedback(@LoginUser Long userId) {
+        return ApiResponse.onSuccess(adminService.getAllFeedbacks(userId));
     }
 }

--- a/src/main/java/dgu/sw/domain/admin/service/AdminService.java
+++ b/src/main/java/dgu/sw/domain/admin/service/AdminService.java
@@ -15,18 +15,18 @@ import java.util.List;
 
 public interface AdminService {
     AdminLoginResponse login(AdminLoginRequest request);
-    List<AdminUserResponse> getAllUsers(String userId);
-    List<AdminMannerResponse> getAllManners(String userId);
-    void deleteManner(Long mannerId, String userId);
-    void saveManner(AdminMannerRequest request, String userId);
-    void updateManner(Long mannerId, AdminMannerRequest request, String userId);
-    List<AdminQuizResponse> getAllQuizzes(String userId);
-    void saveQuiz(AdminQuizRequest request, String userId);
-    void updateQuiz(Long quizId, AdminQuizRequest request, String userId);
-    void deleteQuiz(Long quizId, String userId);
-    List<AdminVocaResponse> getAllVocas(String userId);
-    void saveVoca(AdminVocaRequest request, String userId);
-    void updateVoca(Long vocaId, AdminVocaRequest request, String userId);
-    void deleteVoca(Long vocaId, String userId);
-    List<AdminFeedbackResponse> getAllFeedbacks(String userId);
+    List<AdminUserResponse> getAllUsers(Long userId);
+    List<AdminMannerResponse> getAllManners(Long userId);
+    void deleteManner(Long mannerId, Long userId);
+    void saveManner(AdminMannerRequest request, Long userId);
+    void updateManner(Long mannerId, AdminMannerRequest request, Long userId);
+    List<AdminQuizResponse> getAllQuizzes(Long userId);
+    void saveQuiz(AdminQuizRequest request, Long userId);
+    void updateQuiz(Long quizId, AdminQuizRequest request, Long userId);
+    void deleteQuiz(Long quizId, Long userId);
+    List<AdminVocaResponse> getAllVocas(Long userId);
+    void saveVoca(AdminVocaRequest request, Long userId);
+    void updateVoca(Long vocaId, AdminVocaRequest request, Long userId);
+    void deleteVoca(Long vocaId, Long userId);
+    List<AdminFeedbackResponse> getAllFeedbacks(Long userId);
 }

--- a/src/main/java/dgu/sw/domain/manner/controller/MannerController.java
+++ b/src/main/java/dgu/sw/domain/manner/controller/MannerController.java
@@ -1,16 +1,15 @@
 package dgu.sw.domain.manner.controller;
 
-import dgu.sw.domain.manner.dto.MannerDTO;
+import dgu.sw.domain.manner.dto.MannerDTO.MannerResponse.MannerDetailResponse;
+import dgu.sw.domain.manner.dto.MannerDTO.MannerResponse.MannerFavoriteResponse;
+import dgu.sw.domain.manner.dto.MannerDTO.MannerResponse.MannerListResponse;
 import dgu.sw.domain.manner.service.MannerService;
 import dgu.sw.global.ApiResponse;
+import dgu.sw.global.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-import dgu.sw.domain.manner.dto.MannerDTO.MannerResponse.MannerFavoriteResponse;
-import dgu.sw.domain.manner.dto.MannerDTO.MannerResponse.MannerDetailResponse;
-import dgu.sw.domain.manner.dto.MannerDTO.MannerResponse.MannerListResponse;
 
 import java.util.List;
 
@@ -26,8 +25,7 @@ public class MannerController {
     @Operation(summary = "카테고리 리스트 반환", description = "특정 카테고리의 매너 리스트를 반환합니다.")
     public ApiResponse<List<MannerListResponse>> getMannersByCategory(
             @RequestParam int category,
-            Authentication authentication) {
-        String userId = authentication != null ? authentication.getName() : null;
+            @LoginUser Long userId) {
         return ApiResponse.onSuccess(mannerService.getMannersByCategory(category, userId));
     }
 
@@ -36,8 +34,7 @@ public class MannerController {
     @Operation(summary = "매너 디테일 반환", description = "특정 매너 설명서의 디테일을 반환합니다.")
     public ApiResponse<MannerDetailResponse> getMannerDetail(
             @PathVariable Long mannerId,
-            Authentication authentication) {
-        String userId = authentication != null ? authentication.getName() : null;
+            @LoginUser Long userId) {
         return ApiResponse.onSuccess(mannerService.getMannerDetail(mannerId, userId));
     }
 
@@ -60,23 +57,23 @@ public class MannerController {
     // 5. 즐겨찾기 추가
     @PostMapping("/likes/{mannerId}")
     @Operation(summary = "즐겨찾기 추가", description = "즐겨찾기 리스트에 추가합니다.")
-    public ApiResponse<String> addFavorite(@PathVariable Long mannerId, Authentication authentication) {
-        mannerService.addFavorite(authentication.getName(), mannerId);
+    public ApiResponse<String> addFavorite(@PathVariable Long mannerId, @LoginUser Long userId) {
+        mannerService.addFavorite(userId, mannerId);
         return ApiResponse.onSuccess("즐겨찾기에 추가되었습니다.");
     }
 
     // 6. 즐겨찾기 삭제
     @DeleteMapping("/likes/{mannerId}")
     @Operation(summary = "즐겨찾기 삭제", description = "즐겨찾기 리스트에서 삭제합니다.")
-    public ApiResponse<String> removeFavorite(@PathVariable Long mannerId, Authentication authentication) {
-        mannerService.removeFavorite(authentication.getName(), mannerId);
+    public ApiResponse<String> removeFavorite(@PathVariable Long mannerId, @LoginUser Long userId) {
+        mannerService.removeFavorite(userId, mannerId);
         return ApiResponse.onSuccess("즐겨찾기에서 삭제되었습니다.");
     }
 
     // 7. 즐겨찾기 조회
     @GetMapping("/likes")
     @Operation(summary = "즐겨찾기 조회", description = "로그인한 사용자의 즐겨찾기 리스트를 조회합니다.")
-    public ApiResponse<List<MannerFavoriteResponse>> getFavorites(Authentication authentication) {
-        return ApiResponse.onSuccess(mannerService.getFavorites(authentication.getName()));
+    public ApiResponse<List<MannerFavoriteResponse>> getFavorites(@LoginUser Long userId) {
+        return ApiResponse.onSuccess(mannerService.getFavorites(userId));
     }
 }

--- a/src/main/java/dgu/sw/domain/manner/service/MannerService.java
+++ b/src/main/java/dgu/sw/domain/manner/service/MannerService.java
@@ -7,11 +7,11 @@ import dgu.sw.domain.manner.dto.MannerDTO.MannerResponse.MannerListResponse;
 import java.util.List;
 
 public interface MannerService {
-    List<MannerListResponse> getMannersByCategory(int category, String userId);
-    MannerDetailResponse getMannerDetail(Long mannerId, String userId);
+    List<MannerListResponse> getMannersByCategory(int category, Long userId);
+    MannerDetailResponse getMannerDetail(Long mannerId, Long userId);
     List<MannerListResponse> searchManners(String keyword);
     List<MannerListResponse> searchMannersByCategory(int category, String keyword);
-    void addFavorite(String userId, Long mannerId);
-    void removeFavorite(String userId, Long mannerId);
-    List<MannerFavoriteResponse> getFavorites(String userId);
+    void addFavorite(Long userId, Long mannerId);
+    void removeFavorite(Long userId, Long mannerId);
+    List<MannerFavoriteResponse> getFavorites(Long userId);
 }

--- a/src/main/java/dgu/sw/domain/manner/service/MannerServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/manner/service/MannerServiceImpl.java
@@ -28,7 +28,7 @@ public class MannerServiceImpl implements MannerService {
     private final UserRepository userRepository;
 
     @Override
-    public List<MannerListResponse> getMannersByCategory(int category, String userId) {
+    public List<MannerListResponse> getMannersByCategory(int category, Long userId) {
         // int 카테고리를 String으로 매핑
         String categoryName = mapCategoryToString(category);
 
@@ -37,7 +37,7 @@ public class MannerServiceImpl implements MannerService {
                 .map(manner -> {
                     boolean isFavorited = false;
                     if (userId != null) {
-                        User user = userRepository.findById(Long.valueOf(userId)).orElse(null);
+                        User user = userRepository.findById(userId).orElse(null);
                         isFavorited = user != null && favoriteMannerRepository.existsByUserAndManner(user, manner);
                     }
                     return MannerConverter.toMannerListResponse(manner, isFavorited);
@@ -65,13 +65,13 @@ public class MannerServiceImpl implements MannerService {
     }
 
     @Override
-    public MannerDetailResponse getMannerDetail(Long mannerId, String userId) {
+    public MannerDetailResponse getMannerDetail(Long mannerId, Long userId) {
         Manner manner = mannerRepository.findById(mannerId)
                 .orElseThrow(() -> new MannerException(ErrorStatus.MANNER_NOT_FOUND));
 
         boolean isFavorited = false;
         if (userId != null) {
-            User user = userRepository.findById(Long.valueOf(userId)).orElse(null);
+            User user = userRepository.findById(userId).orElse(null);
             isFavorited = user != null && favoriteMannerRepository.existsByUserAndManner(user, manner);
         }
 
@@ -104,8 +104,8 @@ public class MannerServiceImpl implements MannerService {
     }
 
     @Override
-    public void addFavorite(String userId, Long mannerId) {
-        User user = userRepository.findById(Long.valueOf(userId))
+    public void addFavorite(Long userId, Long mannerId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
 
         Manner manner = mannerRepository.findById(mannerId)
@@ -124,8 +124,8 @@ public class MannerServiceImpl implements MannerService {
     }
 
     @Override
-    public void removeFavorite(String userId, Long mannerId) {
-        User user = userRepository.findById(Long.valueOf(userId))
+    public void removeFavorite(Long userId, Long mannerId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
 
         Manner manner = mannerRepository.findById(mannerId)
@@ -138,8 +138,8 @@ public class MannerServiceImpl implements MannerService {
     }
 
     @Override
-    public List<MannerFavoriteResponse> getFavorites(String userId) {
-        User user = userRepository.findById(Long.valueOf(userId))
+    public List<MannerFavoriteResponse> getFavorites(Long userId) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
 
         return favoriteMannerRepository.findByUser(user)

--- a/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
+++ b/src/main/java/dgu/sw/domain/quiz/controller/MockTestController.java
@@ -1,15 +1,15 @@
 package dgu.sw.domain.quiz.controller;
 
-import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.MockTestResultResponse;
-import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestResponse;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestRequest.SubmitMockTestRequest;
 import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestResponse;
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.MockTestResultResponse;
+import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.SubmitMockTestResponse;
 import dgu.sw.domain.quiz.service.MockTestService;
 import dgu.sw.global.ApiResponse;
+import dgu.sw.global.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,8 +24,8 @@ public class MockTestController {
 
     @PostMapping("/start")
     @Operation(summary = "모의고사 시작", description = "랜덤한 10개의 퀴즈로 모의고사를 시작합니다.")
-    public ApiResponse<CreateMockTestResponse> startMockTest(Authentication authentication) {
-        CreateMockTestResponse response = mockTestService.startMockTest(authentication.getName());
+    public ApiResponse<CreateMockTestResponse> startMockTest(@LoginUser Long userId) {
+        CreateMockTestResponse response = mockTestService.startMockTest(userId);
         return ApiResponse.onSuccess(response);
     }
 
@@ -40,8 +40,8 @@ public class MockTestController {
 
     @GetMapping("/result/all")
     @Operation(summary = "전체 모의고사 결과 조회", description = "해당 사용자가 완료한 모든 모의고사 결과를 반환합니다.")
-    public ApiResponse<List<MockTestResultResponse>> getAllMockTestResults(Authentication authentication) {
-        List<MockTestResultResponse> response = mockTestService.getAllMockTestResults(authentication.getName());
+    public ApiResponse<List<MockTestResultResponse>> getAllMockTestResults(@LoginUser Long userId) {
+        List<MockTestResultResponse> response = mockTestService.getAllMockTestResults(userId);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/controller/QuizController.java
+++ b/src/main/java/dgu/sw/domain/quiz/controller/QuizController.java
@@ -1,19 +1,13 @@
 package dgu.sw.domain.quiz.controller;
 
-import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.YesterdayQuizResponse;
-import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizMainPageResponse;
-import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizSearchResponse;
-import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizReviewResponse;
-import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizListResponse;
-import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizDetailResponse;
-import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizResultResponse;
 import dgu.sw.domain.quiz.dto.QuizDTO.QuizRequest.SubmitQuizRequest;
+import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.*;
 import dgu.sw.domain.quiz.service.QuizService;
 import dgu.sw.global.ApiResponse;
+import dgu.sw.global.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -29,76 +23,76 @@ public class QuizController {
     @GetMapping
     @Operation(summary = "퀴즈 목록 조회", description = "카테고리별 퀴즈 리스트를 반환합니다.")
     public ApiResponse<List<QuizListResponse>> getQuizList(
-            Authentication authentication,
+            @LoginUser Long userId,
             @RequestParam int category) {
-        List<QuizListResponse> response = quizService.getQuizList(authentication.getName(), category);
+        List<QuizListResponse> response = quizService.getQuizList(userId, category);
         return ApiResponse.onSuccess(response);
     }
 
     @GetMapping("/{quizId}")
     @Operation(summary = "퀴즈 상세 조회", description = "선택한 퀴즈의 상세 정보를 반환합니다.")
     public ApiResponse<QuizDetailResponse> getQuizDetail(
-            Authentication authentication,
+            @LoginUser Long userId,
             @PathVariable Long quizId) {
-        QuizDetailResponse response = quizService.getQuizDetail(authentication.getName(), quizId);
+        QuizDetailResponse response = quizService.getQuizDetail(userId, quizId);
         return ApiResponse.onSuccess(response);
     }
 
     @PostMapping("/{quizId}/submit")
     @Operation(summary = "퀴즈 답안 제출", description = "사용자가 제출한 답안을 처리하고 정답 여부를 반환합니다.")
     public ApiResponse<QuizResultResponse> submitQuizAnswer(
-            Authentication authentication,
+            @LoginUser Long userId,
             @PathVariable Long quizId,
             @RequestBody SubmitQuizRequest quizAnswerDto) {
-        QuizResultResponse response = quizService.submitQuizAnswer(authentication.getName(), quizId, quizAnswerDto);
+        QuizResultResponse response = quizService.submitQuizAnswer(userId, quizId, quizAnswerDto);
         return ApiResponse.onSuccess(response);
     }
 
     @PostMapping("/{quizId}/review")
     @Operation(summary = "복습 추가", description = "틀린 문제를 복습 리스트에 추가합니다.")
     public ApiResponse<String> addQuizToReview(
-            Authentication authentication,
+            @LoginUser Long userId,
             @PathVariable Long quizId) {
-        quizService.addQuizToReview(authentication.getName(), quizId);
+        quizService.addQuizToReview(userId, quizId);
         return ApiResponse.onSuccess("복습 리스트에 추가되었습니다.");
     }
 
     @GetMapping("/review")
     @Operation(summary = "복습 리스트 조회", description = "사용자의 복습 리스트를 반환합니다.")
-    public ApiResponse<List<QuizReviewResponse>> getReviewList(Authentication authentication) {
-        List<QuizReviewResponse> response = quizService.getReviewList(authentication.getName());
+    public ApiResponse<List<QuizReviewResponse>> getReviewList(@LoginUser Long userId) {
+        List<QuizReviewResponse> response = quizService.getReviewList(userId);
         return ApiResponse.onSuccess(response);
     }
 
     @DeleteMapping("/{quizId}/review")
     @Operation(summary = "복습 리스트 삭제", description = "복습 리스트에서 특정 퀴즈를 삭제합니다.")
     public ApiResponse<String> removeQuizFromReview(
-            Authentication authentication,
+            @LoginUser Long userId,
             @PathVariable Long quizId) {
-        quizService.removeQuizFromReview(authentication.getName(), quizId);
+        quizService.removeQuizFromReview(userId, quizId);
         return ApiResponse.onSuccess("복습 리스트에서 삭제되었습니다.");
     }
 
     @GetMapping("/search")
     @Operation(summary = "퀴즈 검색", description = "키워드와 카테고리를 기반으로 퀴즈를 검색합니다.")
     public ApiResponse<List<QuizSearchResponse>> searchQuizzes(
-            Authentication authentication,
+            @LoginUser Long userId,
             @RequestParam(required = false) String keyword) {
-        List<QuizSearchResponse> response = quizService.searchQuizzes(authentication.getName(), keyword);
+        List<QuizSearchResponse> response = quizService.searchQuizzes(userId, keyword);
         return ApiResponse.onSuccess(response);
     }
 
     @GetMapping("/main")
     @Operation(summary = "퀴즈 메인 정보 조회", description = "어제 푼 퀴즈 수, 진척도, 모의고사 점수, Top5 오답 퀴즈 등 메인 페이지 데이터를 반환합니다.")
-    public ApiResponse<QuizMainPageResponse> getQuizMainInfo(Authentication authentication) {
-        QuizMainPageResponse response = quizService.getQuizMainPageData(authentication.getName());
+    public ApiResponse<QuizMainPageResponse> getQuizMainInfo(@LoginUser Long userId) {
+        QuizMainPageResponse response = quizService.getQuizMainPageData(userId);
         return ApiResponse.onSuccess(response);
     }
 
     @GetMapping("/yesterday")
     @Operation(summary = "어제 푼 퀴즈 조회", description = "어제 푼 퀴즈 목록을 반환합니다.")
-    public ApiResponse<List<YesterdayQuizResponse>> getYesterdayQuizzes(Authentication authentication) {
-        List<YesterdayQuizResponse> response = quizService.getYesterdaySolvedQuizzes(authentication.getName());
+    public ApiResponse<List<YesterdayQuizResponse>> getYesterdayQuizzes(@LoginUser Long userId) {
+        List<YesterdayQuizResponse> response = quizService.getYesterdaySolvedQuizzes(userId);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestService.java
@@ -8,7 +8,7 @@ import dgu.sw.domain.quiz.dto.MockTestDTO.MockTestResponse.CreateMockTestRespons
 import java.util.List;
 
 public interface MockTestService {
-    CreateMockTestResponse startMockTest(String userId);
+    CreateMockTestResponse startMockTest(Long userId);
     SubmitMockTestResponse submitMockTest(Long mockTestId, SubmitMockTestRequest request);
-    List<MockTestResultResponse> getAllMockTestResults(String userId);
+    List<MockTestResultResponse> getAllMockTestResults(Long userId);
 }

--- a/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/MockTestServiceImpl.java
@@ -34,8 +34,8 @@ public class MockTestServiceImpl implements MockTestService {
 
     @Override
     @Transactional
-    public CreateMockTestResponse startMockTest(String userId) {
-        User user = userRepository.findByUserId(Long.valueOf(userId));
+    public CreateMockTestResponse startMockTest(Long userId) {
+        User user = userRepository.findByUserId(userId);
         
         //퀴즈 리스트 생성
         List<Quiz> randomQuizzes = randomQuizListGenerator.generateQuizList();
@@ -114,8 +114,8 @@ public class MockTestServiceImpl implements MockTestService {
     }
 
     @Override
-    public List<MockTestResultResponse> getAllMockTestResults(String userId) {
-        Long uid = Long.valueOf(userId);
+    public List<MockTestResultResponse> getAllMockTestResults(Long userId) {
+        Long uid = userId;
 
         // 사용자의 모든 완료된 모의고사 조회 (정렬 포함)
         List<MockTest> mockTests = mockTestRepository

--- a/src/main/java/dgu/sw/domain/quiz/service/QuizService.java
+++ b/src/main/java/dgu/sw/domain/quiz/service/QuizService.java
@@ -12,13 +12,13 @@ import dgu.sw.domain.quiz.dto.QuizDTO.QuizResponse.QuizSearchResponse;
 import java.util.List;
 
 public interface QuizService {
-    List<QuizListResponse> getQuizList(String userId, int category);
-    QuizDetailResponse getQuizDetail(String userId, Long quizId);
-    QuizResultResponse submitQuizAnswer(String userId, Long quizId, SubmitQuizRequest request);
-    void addQuizToReview(String userId, Long quizId);
-    void removeQuizFromReview(String userId, Long quizId);
-    List<QuizSearchResponse> searchQuizzes(String userId, String keyword);
-    List<QuizReviewResponse> getReviewList(String userId);
-    QuizMainPageResponse getQuizMainPageData(String userId);
-    List<YesterdayQuizResponse> getYesterdaySolvedQuizzes(String userId);
+    List<QuizListResponse> getQuizList(Long userId, int category);
+    QuizDetailResponse getQuizDetail(Long userId, Long quizId);
+    QuizResultResponse submitQuizAnswer(Long userId, Long quizId, SubmitQuizRequest request);
+    void addQuizToReview(Long userId, Long quizId);
+    void removeQuizFromReview(Long userId, Long quizId);
+    List<QuizSearchResponse> searchQuizzes(Long userId, String keyword);
+    List<QuizReviewResponse> getReviewList(Long userId);
+    QuizMainPageResponse getQuizMainPageData(Long userId);
+    List<YesterdayQuizResponse> getYesterdaySolvedQuizzes(Long userId);
 }

--- a/src/main/java/dgu/sw/domain/user/controller/UserController.java
+++ b/src/main/java/dgu/sw/domain/user/controller/UserController.java
@@ -1,16 +1,19 @@
 package dgu.sw.domain.user.controller;
 
-import dgu.sw.domain.user.dto.UserDTO.UserResponse.*;
 import dgu.sw.domain.user.dto.UserDTO.UserRequest.*;
+import dgu.sw.domain.user.dto.UserDTO.UserResponse.MyPageResponse;
+import dgu.sw.domain.user.dto.UserDTO.UserResponse.SignInResponse;
+import dgu.sw.domain.user.dto.UserDTO.UserResponse.SignUpResponse;
+import dgu.sw.domain.user.dto.UserDTO.UserResponse.UpdateJoinDateResponse;
 import dgu.sw.domain.user.service.UserService;
 import dgu.sw.global.ApiResponse;
+import dgu.sw.global.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -89,27 +92,27 @@ public class UserController {
 
     @GetMapping("/mypage")
     @Operation(summary = "마이페이지 조회", description = "유저의 마이페이지 정보를 반환합니다.")
-    public ApiResponse<MyPageResponse> getMyPage(Authentication authentication) {
-        return ApiResponse.onSuccess(userService.getMyPage(authentication.getName()));
+    public ApiResponse<MyPageResponse> getMyPage(@LoginUser Long userId) {
+        return ApiResponse.onSuccess(userService.getMyPage(userId));
     }
 
     @PostMapping("/join-date")
     @Operation(summary = "입사일 최초 등록 API", description = "소셜 로그인 유저의 최초 입사일을 등록합니다. 이미 존재하면 400 반환.")
     public ApiResponse<UpdateJoinDateResponse> registerJoinDate(
-            Authentication authentication,
+            @LoginUser Long userId,
             @RequestBody @Valid RegisterJoinDateRequest request
     ) {
-        UpdateJoinDateResponse response = userService.registerJoinDate(authentication.getName(), request.getJoinDate());
+        UpdateJoinDateResponse response = userService.registerJoinDate(userId, request.getJoinDate());
         return ApiResponse.onSuccess(response);
     }
 
     @PatchMapping("/join-date")
     @Operation(summary = "입사일 변경 API", description = "사용자의 입사일을 수정합니다.")
     public ApiResponse<UpdateJoinDateResponse> updateJoinDate(
-            Authentication authentication,
+            @LoginUser Long userId,
             @RequestBody @Valid UpdateJoinDateRequest request
     ) {
-        UpdateJoinDateResponse response = userService.updateJoinDate(authentication.getName(), request.getJoinDate());
+        UpdateJoinDateResponse response = userService.updateJoinDate(userId, request.getJoinDate());
         return ApiResponse.onSuccess(response);
     }
 
@@ -127,10 +130,10 @@ public class UserController {
     )
     @Operation(summary = "FCM 토큰 등록/수정", description = "모바일 디바이스에서 FCM 토큰을 받아 저장합니다.")
     public ApiResponse<String> updateFcmToken(
-            Authentication authentication,
+            @LoginUser Long userId,
             @RequestBody @Valid FcmTokenUpdateRequest request
     ) {
-        userService.updateFcmToken(authentication.getName(), request.getFcmToken());
+        userService.updateFcmToken(userId, request.getFcmToken());
         return ApiResponse.onSuccess("FCM 토큰이 저장되었습니다.");
     }
 }

--- a/src/main/java/dgu/sw/domain/user/service/UserService.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserService.java
@@ -31,15 +31,15 @@ public interface UserService {
     // 비밀번호 변경, 확인
     void resetPassword(PasswordResetRequest request);
 
-    MyPageResponse getMyPage(String userId);
+    MyPageResponse getMyPage(Long userId);
 
-    UpdateJoinDateResponse updateJoinDate(String userId, LocalDate joinDate);
+    UpdateJoinDateResponse updateJoinDate(Long userId, LocalDate joinDate);
 
     void withdraw(HttpServletRequest request);
 
-    UpdateJoinDateResponse registerJoinDate(String userId, LocalDate joinDate);
+    UpdateJoinDateResponse registerJoinDate(Long userId, LocalDate joinDate);
     // 클라이언트 입장에서 응답은 같으니 Register용을 따로 만들지 않고 Update를 사용!
 
     // 알림 기능
-    void updateFcmToken(String userId, String fcmToken);
+    void updateFcmToken(Long userId, String fcmToken);
 }

--- a/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/user/service/UserServiceImpl.java
@@ -273,14 +273,14 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public MyPageResponse getMyPage(String userId) {
-        User user = userRepository.findByUserId(Long.valueOf(userId));
+    public MyPageResponse getMyPage(Long userId) {
+        User user = userRepository.findByUserId(userId);
         return UserConverter.toMyPageResponse(user);
     }
 
     @Override
-    public UpdateJoinDateResponse updateJoinDate(String userId, LocalDate joinDate) {
-        User user = userRepository.findById(Long.valueOf(userId))
+    public UpdateJoinDateResponse updateJoinDate(Long userId, LocalDate joinDate) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
 
         user.updateJoinDate(joinDate);
@@ -361,8 +361,8 @@ public class UserServiceImpl implements UserService {
 
     // 소셜 로그인용 입사일 등록 API
     @Override
-    public UpdateJoinDateResponse registerJoinDate(String userId, LocalDate joinDate) {
-        User user = userRepository.findById(Long.valueOf(userId))
+    public UpdateJoinDateResponse registerJoinDate(Long userId, LocalDate joinDate) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
 
         // 이미 입사일이 등록되어 있다면 예외 발생
@@ -380,8 +380,8 @@ public class UserServiceImpl implements UserService {
 
     // 알림 기능
     @Override
-    public void updateFcmToken(String userId, String fcmToken) {
-        User user = userRepository.findById(Long.valueOf(userId))
+    public void updateFcmToken(Long userId, String fcmToken) {
+        User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
 
         user.setFcmToken(fcmToken);

--- a/src/main/java/dgu/sw/domain/voca/controller/VocaController.java
+++ b/src/main/java/dgu/sw/domain/voca/controller/VocaController.java
@@ -4,6 +4,7 @@ import dgu.sw.domain.voca.dto.VocaDTO.VocaResponse.VocaListResponse;
 import dgu.sw.domain.voca.dto.VocaDTO.VocaResponse.VocaFavoriteResponse;
 import dgu.sw.domain.voca.service.VocaService;
 import dgu.sw.global.ApiResponse;
+import dgu.sw.global.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -24,8 +25,7 @@ public class VocaController {
     @Operation(summary = "업무 용어 리스트 조회", description = "카테고리별 업무 용어 리스트를 반환합니다.")
     public ApiResponse<List<VocaListResponse>> getVocaList(
             @RequestParam String category,
-            Authentication authentication) {
-        String userId = (authentication != null) ? authentication.getName() : null;
+            @LoginUser Long userId) {
         List<VocaListResponse> response = vocaService.getVocaList(userId, category);
         return ApiResponse.onSuccess(response);
     }
@@ -34,30 +34,29 @@ public class VocaController {
     @Operation(summary = "업무 용어 검색", description = "키워드로 업무 용어를 검색합니다.")
     public ApiResponse<List<VocaListResponse>> searchVoca(
             @RequestParam String keyword,
-            Authentication authentication) {
-        String userId = (authentication != null) ? authentication.getName() : null;
+            @LoginUser Long userId) {
         List<VocaListResponse> response = vocaService.searchVoca(userId, keyword);
         return ApiResponse.onSuccess(response);
     }
 
     @PostMapping("/likes/{vocaId}")
     @Operation(summary = "업무 용어 즐겨찾기 추가", description = "업무 용어를 즐겨찾기에 추가합니다.")
-    public ApiResponse<String> addFavorite(@PathVariable Long vocaId, Authentication authentication) {
-        vocaService.addFavorite(authentication.getName(), vocaId);
+    public ApiResponse<String> addFavorite(@PathVariable Long vocaId, @LoginUser Long userId) {
+        vocaService.addFavorite(userId, vocaId);
         return ApiResponse.onSuccess("즐겨찾기에 추가되었습니다.");
     }
 
     @DeleteMapping("/likes/{vocaId}")
     @Operation(summary = "업무 용어 즐겨찾기 삭제", description = "업무 용어를 즐겨찾기에서 삭제합니다.")
-    public ApiResponse<String> removeFavorite(@PathVariable Long vocaId, Authentication authentication) {
-        vocaService.removeFavorite(authentication.getName(), vocaId);
+    public ApiResponse<String> removeFavorite(@PathVariable Long vocaId, @LoginUser Long userId) {
+        vocaService.removeFavorite(userId, vocaId);
         return ApiResponse.onSuccess("즐겨찾기에서 삭제되었습니다.");
     }
 
     @GetMapping("/likes")
     @Operation(summary = "즐겨찾기 조회", description = "사용자의 즐겨찾기 리스트를 반환합니다.")
-    public ApiResponse<List<VocaFavoriteResponse>> getFavorites(Authentication authentication) {
-        List<VocaFavoriteResponse> response = vocaService.getFavorites(authentication.getName());
+    public ApiResponse<List<VocaFavoriteResponse>> getFavorites(@LoginUser Long userId) {
+        List<VocaFavoriteResponse> response = vocaService.getFavorites(userId);
         return ApiResponse.onSuccess(response);
     }
 }

--- a/src/main/java/dgu/sw/domain/voca/service/VocaService.java
+++ b/src/main/java/dgu/sw/domain/voca/service/VocaService.java
@@ -6,13 +6,13 @@ import dgu.sw.domain.voca.dto.VocaDTO.VocaResponse.VocaFavoriteResponse;
 import java.util.List;
 
 public interface VocaService {
-    List<VocaListResponse> getVocaList(String userId, String category);
+    List<VocaListResponse> getVocaList(Long userId, String category);
 
-    List<VocaListResponse> searchVoca(String userId, String keyword);
+    List<VocaListResponse> searchVoca(Long userId, String keyword);
 
-    void addFavorite(String userId, Long vocaId);
+    void addFavorite(Long userId, Long vocaId);
 
-    void removeFavorite(String userId, Long vocaId);
+    void removeFavorite(Long userId, Long vocaId);
 
-    List<VocaFavoriteResponse> getFavorites(String userId);
+    List<VocaFavoriteResponse> getFavorites(Long userId);
 }

--- a/src/main/java/dgu/sw/domain/voca/service/VocaServiceImpl.java
+++ b/src/main/java/dgu/sw/domain/voca/service/VocaServiceImpl.java
@@ -1,16 +1,15 @@
 package dgu.sw.domain.voca.service;
 
+import dgu.sw.domain.user.entity.User;
+import dgu.sw.domain.user.repository.UserRepository;
 import dgu.sw.domain.voca.converter.VocaConverter;
-import dgu.sw.domain.voca.dto.VocaDTO.VocaResponse.VocaListResponse;
 import dgu.sw.domain.voca.dto.VocaDTO.VocaResponse.VocaFavoriteResponse;
+import dgu.sw.domain.voca.dto.VocaDTO.VocaResponse.VocaListResponse;
 import dgu.sw.domain.voca.entity.FavoriteVoca;
 import dgu.sw.domain.voca.entity.Voca;
 import dgu.sw.domain.voca.repository.FavoriteVocaRepository;
 import dgu.sw.domain.voca.repository.VocaRepository;
-import dgu.sw.domain.user.entity.User;
-import dgu.sw.domain.user.repository.UserRepository;
 import dgu.sw.global.exception.VocaException;
-import dgu.sw.global.exception.UserException;
 import dgu.sw.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,7 +26,7 @@ public class VocaServiceImpl implements VocaService {
     private final UserRepository userRepository;
 
     @Override
-    public List<VocaListResponse> getVocaList(String userId, String category) {
+    public List<VocaListResponse> getVocaList(Long userId, String category) {
         // 카테고리별 업무 용어 조회
         List<Voca> vocas = vocaRepository.findByCategory(category);
 
@@ -37,7 +36,7 @@ public class VocaServiceImpl implements VocaService {
 
         // 로그인 여부에 따라 즐겨찾기 처리
         List<Long> favoritedVocaIds = (userId != null)
-                ? favoriteVocaRepository.findByUser(userRepository.findByUserId(Long.valueOf(userId))).stream()
+                ? favoriteVocaRepository.findByUser(userRepository.findByUserId(userId)).stream()
                 .map(favorite -> favorite.getVoca().getVocaId())
                 .collect(Collectors.toList())
                 : List.of();
@@ -50,7 +49,7 @@ public class VocaServiceImpl implements VocaService {
     }
 
     @Override
-    public List<VocaListResponse> searchVoca(String userId, String keyword) {
+    public List<VocaListResponse> searchVoca(Long userId, String keyword) {
         List<Voca> vocas = vocaRepository.findByTermContainingOrDescriptionContaining(keyword, keyword);
 
         if (vocas.isEmpty()) {
@@ -59,7 +58,7 @@ public class VocaServiceImpl implements VocaService {
 
         // 로그인 여부에 따라 즐겨찾기 처리
         List<Long> favoritedVocaIds = (userId != null)
-                ? favoriteVocaRepository.findByUser(userRepository.findByUserId(Long.valueOf(userId))).stream()
+                ? favoriteVocaRepository.findByUser(userRepository.findByUserId(userId)).stream()
                 .map(favorite -> favorite.getVoca().getVocaId())
                 .collect(Collectors.toList())
                 : List.of();
@@ -72,8 +71,8 @@ public class VocaServiceImpl implements VocaService {
     }
 
     @Override
-    public void addFavorite(String userId, Long vocaId) {
-        User user = userRepository.findByUserId(Long.valueOf(userId));
+    public void addFavorite(Long userId, Long vocaId) {
+        User user = userRepository.findByUserId(userId);
         Voca voca = vocaRepository.findById(vocaId)
                 .orElseThrow(() -> new VocaException(ErrorStatus.VOCA_NOT_FOUND));
 
@@ -86,8 +85,8 @@ public class VocaServiceImpl implements VocaService {
     }
 
     @Override
-    public void removeFavorite(String userId, Long vocaId) {
-        User user = userRepository.findByUserId(Long.valueOf(userId));
+    public void removeFavorite(Long userId, Long vocaId) {
+        User user = userRepository.findByUserId(userId);
         Voca voca = vocaRepository.findById(vocaId)
                 .orElseThrow(() -> new VocaException(ErrorStatus.VOCA_NOT_FOUND));
 
@@ -98,8 +97,8 @@ public class VocaServiceImpl implements VocaService {
     }
 
     @Override
-    public List<VocaFavoriteResponse> getFavorites(String userId) {
-        User user = userRepository.findByUserId(Long.valueOf(userId));
+    public List<VocaFavoriteResponse> getFavorites(Long userId) {
+        User user = userRepository.findByUserId(userId);
         List<FavoriteVoca> favorites = favoriteVocaRepository.findByUser(user);
         return favorites.stream()
                 .map(favorite -> VocaConverter.toVocaFavoriteResponse(favorite.getVoca()))

--- a/src/main/java/dgu/sw/global/exception/AdminException.java
+++ b/src/main/java/dgu/sw/global/exception/AdminException.java
@@ -1,0 +1,9 @@
+package dgu.sw.global.exception;
+
+import dgu.sw.global.status.ErrorStatus;
+
+public class AdminException extends GeneralException {
+  public AdminException(ErrorStatus code) {
+    super(code);
+  }
+}

--- a/src/main/java/dgu/sw/global/status/ErrorStatus.java
+++ b/src/main/java/dgu/sw/global/status/ErrorStatus.java
@@ -38,7 +38,12 @@ public enum ErrorStatus implements BaseErrorCode {
     JOIN_DATE_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "USER4012", "이미 입사일이 등록된 사용자입니다."),
     SOCIAL_USER_CANNOT_CHANGE_PASSWORD(HttpStatus.FORBIDDEN, "USER4013", "소셜 로그인 사용자는 비밀번호를 변경할 수 없습니다."),
     LOGGED_OUT_TOKEN(HttpStatus.UNAUTHORIZED, "USER4013", "이미 로그아웃된 토큰입니다."),
-    FORBIDDEN_ACCESS(HttpStatus.UNAUTHORIZED, "USER4014", "관리자 권한이 없습니다."),
+
+    // 관리자 관련 에러
+    ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "ADMIN4001", "존재하지 않는 관리자입니다."),
+    ADMIN_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "ADMIN4002", "관리자 이메일 또는 비밀번호가 올바르지 않습니다."),
+    ADMIN_FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "ADMIN4003", "관리자 권한이 없습니다."),
+    ADMIN_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "ADMIN4004", "인증되지 않은 관리자 요청입니다."),
 
     // 업무 용어 관련 에러
     VOCA_NOT_FOUND(HttpStatus.NOT_FOUND, "VOCA4041", "해당 업무 용어를 찾을 수 없습니다."),


### PR DESCRIPTION
## Related Issue 🍀
- #216 

<br>

## Key Changes 🔑
- 반복적으로 사용되던 Authentication.getName() 호출을 제거하고, 커스텀 애노테이션 @LoginUser를 도입하여 인증된 사용자 ID를 간결하게 주입받도록 리팩토링
- 기존 String userId → Long userId로 통일
- 서비스 계층에서 수행되던 Long.valueOf(userId) 변환 로직 제거 → 타입 불일치 문제 예방

<br>

## To Reviewers 🙏🏻
- 로그인하지 않은 사용자도 매너 설명서, 업무 용어, 퀴즈 등의 컨텐츠를 조회 가능하도록 허용해보자 !